### PR TITLE
A few iperf updates

### DIFF
--- a/iperf-client
+++ b/iperf-client
@@ -182,7 +182,7 @@ case "${cpu_pin}" in
 	;;
 esac
 
-options="--format g -c $remotehost -p $control_port $protocol $length --get-server-output"
+options="--format k -c $remotehost -p $control_port $protocol $length --get-server-output"
 #options+=" --cport $data_port"
 # strip ',' from the passthru options 
 passthru_opts=$(echo "$pt_opts" | sed 's/,/ /g')

--- a/iperf-post-process
+++ b/iperf-post-process
@@ -76,6 +76,7 @@ foreach my $i (qw(begin end)) {
 #
 sub process_proto {
     my $bitrate;
+    my $bitrate_div;
     my $interval;
     print "process_proto: enter\n";
     my $rateunit='none';
@@ -139,21 +140,18 @@ sub process_proto {
                     $bitrate = $columns[6];
                     debug_print("bitrate $bitrate\n");
 
-                    $rateunit = $columns[7];
-
-                    # Always convert to common rate unit so results can be compared regardless of --format
-                    my $rate_divisor = 1;
-                    if ( $rateunit eq "Kbits/sec" ) {
-                        $rateunit = "Gbps";
-                        $bitrate /= 1000000;
-                    } elsif ( $rateunit eq "Mbits/sec" ) {
-                        $rateunit = "Gbps";
-                        $bitrate /= 1000;
-                    } elsif ( $rateunit eq "Gbits/sec" ) {
-                        $rateunit = "Gbps";
-                    } else {
-                        printf "Error: Did not recongnize rate unit: %s\n", $rateunit;
-                        exit 1;
+                    if ( $rateunit eq 'none' ) {
+                        $rateunit = $columns[7];
+                        if ( $rateunit eq "Kbits/sec" ) {
+                            $bitrate_div = 1000000;
+                        } elsif ( $rateunit eq "Mbits/sec" ) {
+                            $bitrate_div = 1000;
+                        } elsif ( $rateunit eq "Gbits/sec" ) {
+                            $bitrate_div = 1;
+                        } else {
+                            printf "Error: Did not recongnize rate unit: %s\n", $rateunit;
+                            exit 1;
+                        }
                     }
 
                     $ts_end=$ts + $interval -1;
@@ -175,18 +173,18 @@ sub process_proto {
 
                         if ( ! defined  $primary_metric ) {
                             # rx throughput is our primary_metric.
-                            $primary_metric = "rx-$rateunit";
+                            $primary_metric = "rx-Gbps";
                             debug_print("primary_metric $primary_metric\n");
                         }
                         %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => $primary_metric);
 
                     } else {
                         # no "Lost/Total" column implies tx section
-                        %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => "tx-$rateunit");
+                        %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => "tx-Gbps");
                     }
 
                     # log rx "bitrate" sample
-                    %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' => $bitrate);
+                    %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' => ($bitrate / $bitrate_div));
                     print ("begin: int $ts, end: int $ts_end\n");
                     log_sample("0", \%desc, \%names, \%s);
                     $ts=$ts+$interval;
@@ -210,7 +208,7 @@ sub process_proto {
                 #	[ ID] Interval           Transfer     Bitrate
                 #	[  5]   0.00-30.00  sec  17.5 GBytes  5.00 Gbits/sec                  receiver
 
-                if ( /sec/ ) {
+                if ( /sec\s/ ) {
                     debug_print("Proc line: $_"); 
                     my $retry;
                     my @columns = split(/\s+/, $_);
@@ -231,22 +229,21 @@ sub process_proto {
                
                     $bitrate = $columns[6];
                     debug_print("bitrate $bitrate\n"); 
-                    $rateunit = $columns[7];
 
-                    # Always convert to common rate unit so results can be compared regardless of --format
-                    my $rate_divisor = 1;
-                    if ( $rateunit eq "Kbits/sec" ) {
-                        $rateunit = "Gbps";
-                        $bitrate /= 1000000;
-                    } elsif ( $rateunit eq "Mbits/sec" ) {
-                        $rateunit = "Gbps";
-                        $bitrate /= 1000;
-                    } elsif ( $rateunit eq "Gbits/sec" ) {
-                        $rateunit = "Gbps";
-                    } else {
-                        printf "Error: Did not recongnize rate unit: %s\n", $rateunit;
-                        exit 1;
+                    if ( $rateunit eq 'none' ) {
+                        $rateunit = $columns[7];
+                        if ( $rateunit eq "Kbits/sec" ) {
+                            $bitrate_div = 1000000;
+                        } elsif ( $rateunit eq "Mbits/sec" ) {
+                            $bitrate_div = 1000;
+                        } elsif ( $rateunit eq "Gbits/sec" ) {
+                            $bitrate_div = 1;
+                        } else {
+                            printf "Error: Did not recongnize rate unit: %s\n", $rateunit;
+                            exit 1;
+                        }
                     }
+
                     my $num_fields = scalar @columns;
                     debug_print("num_fields: $num_fields\n"); 
                     $ts_end=$ts + $interval -1;
@@ -259,18 +256,18 @@ sub process_proto {
                         %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' =>  $retry);
                         log_sample("0", \%desc, \%names, \%s);
 
-                        %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => "tx-$rateunit");
+                        %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => "tx-Gbps");
                     } else {
                         # no "Retr" column implies rx side
                         if ( ! defined  $primary_metric ) {
-                            $primary_metric = "rx-$rateunit";
+                            $primary_metric = "rx-Gbps";
                             debug_print("primary_metric $primary_metric\n");
                         }
                         %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => $primary_metric);
 
                     }
                     # log rx "bitrate" sample
-                    %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' => $bitrate);
+                    %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' => ($bitrate / $bitrate_div));
 
                     log_sample("0", \%desc, \%names, \%s);
                     $ts=$ts+$interval;

--- a/iperf-post-process
+++ b/iperf-post-process
@@ -139,8 +139,21 @@ sub process_proto {
                     $bitrate = $columns[6];
                     debug_print("bitrate $bitrate\n");
 
-                    if ( $rateunit eq 'none' ) {
-                        $rateunit = $columns[7];
+                    $rateunit = $columns[7];
+
+                    # Always convert to common rate unit so results can be compared regardless of --format
+                    my $rate_divisor = 1;
+                    if ( $rateunit eq "Kbits/sec" ) {
+                        $rateunit = "Gbps";
+                        $bitrate /= 1000000;
+                    } elsif ( $rateunit eq "Mbits/sec" ) {
+                        $rateunit = "Gbps";
+                        $bitrate /= 1000;
+                    } elsif ( $rateunit eq "Gbits/sec" ) {
+                        $rateunit = "Gbps";
+                    } else {
+                        printf "Error: Did not recongnize rate unit: %s\n", $rateunit;
+                        exit 1;
                     }
 
                     $ts_end=$ts + $interval -1;
@@ -152,11 +165,11 @@ sub process_proto {
                         my $total = $tuble[1];
                         debug_print("Lost:$lost Total:$total\n");
 
-                        %desc = ('source' => 'iperf', 'class' => 'count', 'type' => 'rx-lost/sec');
+                        %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => 'rx-lost/sec');
                         %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' =>  $lost);
                         log_sample("0", \%desc, \%names, \%s);
 
-                        %desc = ('source' => 'iperf', 'class' => 'count', 'type' => 'rx-pps');
+                        %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => 'rx-pps');
                         %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' => $total);
                         log_sample("0", \%desc, \%names, \%s);
 
@@ -218,8 +231,21 @@ sub process_proto {
                
                     $bitrate = $columns[6];
                     debug_print("bitrate $bitrate\n"); 
-                    if ( $rateunit eq 'none' ) {
-                        $rateunit = $columns[7];
+                    $rateunit = $columns[7];
+
+                    # Always convert to common rate unit so results can be compared regardless of --format
+                    my $rate_divisor = 1;
+                    if ( $rateunit eq "Kbits/sec" ) {
+                        $rateunit = "Gbps";
+                        $bitrate /= 1000000;
+                    } elsif ( $rateunit eq "Mbits/sec" ) {
+                        $rateunit = "Gbps";
+                        $bitrate /= 1000;
+                    } elsif ( $rateunit eq "Gbits/sec" ) {
+                        $rateunit = "Gbps";
+                    } else {
+                        printf "Error: Did not recongnize rate unit: %s\n", $rateunit;
+                        exit 1;
                     }
                     my $num_fields = scalar @columns;
                     debug_print("num_fields: $num_fields\n"); 

--- a/iperf-server-start
+++ b/iperf-server-start
@@ -162,7 +162,7 @@ esac
 
 
 passthru_opts=$(echo "$pt_opts" | sed 's/,/ /g')
-cmd="${cpu_pin_cmd} iperf3 -s --format g -p $control_port $passthru_opts"
+cmd="${cpu_pin_cmd} iperf3 -s --format k -p $control_port $passthru_opts"
 echo "going to run: $cmd"
 export MALLOC_CHECK_=2
 $cmd 2>&1 >iperf-server-result.txt &


### PR DESCRIPTION
- default to Kbytes/sec to get more precision in bitrate data (Gbps
  limited to .00)
- always convert bitrate to "Gbps" regardless of native-benchmark
  output, so comparisons can always be easily made even if user
  chooses a different iperf output