### PR TITLE
iperf - miscellaneous: omit option, cpu-numa pinning, run-time computation

### DIFF
--- a/iperf-post-process
+++ b/iperf-post-process
@@ -34,7 +34,8 @@ my $ts;
 my $ts_end;
 my %times;
 my $hunting_mode=0;
-my $omit=2;
+# omit is a utility feature for re post-process and ignore a number of first second drops.
+my $omit=0;
 use constant SEC_TO_MSEC => 1000;
 use constant KBPS_TO_GBPS => 1000000;
 

--- a/iperf-server-start
+++ b/iperf-server-start
@@ -152,7 +152,7 @@ if [ ! -z "$ifname" ]; then
         echo "IP was found: $ip"
     fi
 else
-    echo "Not going to look for an IP since --server-ifname was not used."
+    echo "Not going to look for an IP since --ifname was not used."
 fi
 
 # Queue ip/port info, to be sent to endpoint


### PR DESCRIPTION
Description: 
This commit contains miscellaneous tweaks:
+ omit: a special postprocessing option to ignore first few seconds worth of results as warm-up period.
+ cpu-numa: option to pin client and server to same NUMA if possible, but owned CPU
+ runtime: compute runtime according to 'time' params taken 0-drop hunting iterations into account.