### PR TITLE
Runtime pin

### DIFF
--- a/iperf-base
+++ b/iperf-base
@@ -1,3 +1,37 @@
 #!/bin/bash
 
 if ! source ${TOOLBOX_HOME}/bash/library/bench-base; then echo "ERROR: Could not source bench-base from \$TOOLBOX_HOME [${TOOLBOX_HOME}]"; exit 1; fi
+
+#
+# Assign last CPU in list to client role, and next to last CPU to server role.
+# For PIN functionality, we want same NUMA and separate CPU for client and server.
+# The caller provides the CPU list of its chosen NUMA.
+#
+# Argument: <role> i.e cient or server
+# Argument: <cpu_list>, a comma separated cpu list
+# Return: 
+#  1. Do nothing if cpu list contains less than 2 CPUs.
+#  2. Else, initialize cpu_pin_cmd="taskset --cpu-list chosen_cpu"
+#       
+function assign-pin-cpu {
+    local my_cpu
+    local array
+    local cpu_list=$2
+
+    # convert comma-separate list to array, for access by index
+    IFS=',' read -r -a array <<< $cpu_list
+    if [ "${#array[@]}" -lt 2 ]; then
+        return
+    fi
+
+    if [ "$1" == "client" ]; then
+        # client - assign last CPU in the list
+        my_cpu=${array[${#array[@]}-1]}
+    else
+        # server - assign next to last CPU in the list
+        my_cpu=${array[${#array[@]}-2]}
+    fi
+    cpu_pin_cmd="taskset --cpu-list ${my_cpu}"
+    echo $1: $cpu_pin_cmd
+}
+

--- a/iperf-client
+++ b/iperf-client
@@ -182,8 +182,7 @@ if [ -e /sys/class/net/${ifname}/device/numa_node ]; then
         ifname_numa_node=0
     fi
 else
-    # When topo=internode topo, the device is eth0. Default it to numa node0.
-    # In other word, if there is no numa associated with ifname, just use numa 0
+    # If there is no numa associated with ifname, just use numa 0.
     ifname_numa_node=0
 fi
 
@@ -215,29 +214,14 @@ echo "data_port=$data_port"
 echo "time=$time"
 echo "length=$length"
 echo "protocol=$protocol"
-
-
-function assign-pin-cpu {
-    local my_cpu
-    # iperf PIN is to pin same NUMA and 1 CPU 
-    IFS=',' read -r -a array <<< "$ifname_numa_node_cpus"
-    if [ "$1" == "client" ]; then
-        my_cpu=${array[${#array[@]}-1]}
-    else
-        my_cpu=${array[${#array[@]}-2]}
-    fi
-	cpu_pin_cmd="taskset --cpu-list ${my_cpu}"
-    echo $1: $cpu_pin_cmd
-}
-
 cpu_pin_cmd=""
 case "${cpu_pin}" in
     "numa")
-	cpu_pin_cmd="taskset --cpu-list ${ifname_numa_node_cpus}"
-	;;
+        cpu_pin_cmd="taskset --cpu-list ${ifname_numa_node_cpus}"
+        ;;
     "cpu-numa")
-    assign-pin-cpu client
-	;;
+        assign-pin-cpu client ${ifname_numa_node_cpus}
+        ;;
 esac
 
 options="--format k -c $remotehost -p $control_port $protocol $length --get-server-output"

--- a/iperf-client
+++ b/iperf-client
@@ -23,9 +23,10 @@ ipv="4"
 bstart=0
 bend=0
 bitrate_range=
+omit=0
 
 echo "opts before: $@"
-longopts="ifname:,protocol:,length:,remotehost:,time:,bitrate:,cpu-pin:,passthru:,bitrate-range:"
+longopts="ipv:,ifname:,protocol:,length:,remotehost:,time:,bitrate:,cpu-pin:,passthru:,bitrate-range:,omit:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     exit_error "Unrecognized option specified"
@@ -98,6 +99,12 @@ while true; do
             bend=$(echo $bitrate_range | awk -F'-' '{print $2}')
             shift
             ;;
+        --omit)     # skip first number of seconds
+            shift;
+            omit=$1
+            echo "omit=$omit"
+            shift
+            ;;
         --)
             shift;
             break
@@ -108,7 +115,7 @@ while true; do
 done
 
 case "${cpu_pin}" in
-    ""|"numa")
+    ""|"numa"|"cpu-numa")
 	;;
     *)
 	exit_error "unsupported cpu-pin value '${cpu_pin}'"
@@ -157,20 +164,36 @@ if [ -z "$remotehost" ]; then
 fi
 # TODO: validate $remotehost with regex
 
+#
+# The cpu_pin="cpu-numa" mode, pin client and server to a CPU.
+# If they colocate (INTRA-xxx), they should also be on the same NUMA.
+#
 ifname=$(ip route get ${remotehost} | head -n 1 | awk -F" dev " '{ print $2 }' | awk -F" src " '{ print $1 }')
 if [ ! -e /sys/class/net/${ifname} ]; then
     exit_error "invalid interface '${ifname}' found"
 fi
 
-ifname_numa_node=-1
-ifname_numa_node_cpus=-1
+ifname_numa_node=
+ifname_numa_node_cpus=
 if [ -e /sys/class/net/${ifname}/device/numa_node ]; then
     ifname_numa_node=$(cat /sys/class/net/${ifname}/device/numa_node)
-
-    ifname_numa_node_cpus=$(cat /sys/devices/system/node/node${ifname_numa_node}/cpulist)
-elif [ "${cpu_pin}" == "numa" ]; then
-    exit_error "cannot determine numa node for interface '${ifname}' and cpu-pin is numa"
+    if [ "$ifname_numa_node" == "-1" ]; then
+        # VM case, use numa 0
+        ifname_numa_node=0
+    fi
+else
+    # When topo=internode topo, the device is eth0. Default it to numa node0.
+    # In other word, if there is no numa associated with ifname, just use numa 0
+    ifname_numa_node=0
 fi
+
+ifname_numa_node_cpus=$(cat /sys/devices/system/node/node${ifname_numa_node}/cpulist)
+# convert to comma separated list if there are ranges i.e 0-5 items
+ifname_numa_node_cpus=$(echo $ifname_numa_node_cpus | perl -pe 's/(\d+)-(\d+)/join(",",$1..$2)/eg')
+echo "ifname=${ifname}"
+echo "ifname_numa_node=${ifname_numa_node}"
+echo "ifname_numa_node_cpus=${ifname_numa_node_cpus}"
+
 
 # These ports should come from the endpoint, but if for some
 # reason they don't the default port numbers are calculated
@@ -193,14 +216,35 @@ echo "time=$time"
 echo "length=$length"
 echo "protocol=$protocol"
 
+
+function assign-pin-cpu {
+    local my_cpu
+    # iperf PIN is to pin same NUMA and 1 CPU 
+    IFS=',' read -r -a array <<< "$ifname_numa_node_cpus"
+    if [ "$1" == "client" ]; then
+        my_cpu=${array[${#array[@]}-1]}
+    else
+        my_cpu=${array[${#array[@]}-2]}
+    fi
+	cpu_pin_cmd="taskset --cpu-list ${my_cpu}"
+    echo $1: $cpu_pin_cmd
+}
+
 cpu_pin_cmd=""
 case "${cpu_pin}" in
     "numa")
 	cpu_pin_cmd="taskset --cpu-list ${ifname_numa_node_cpus}"
 	;;
+    "cpu-numa")
+    assign-pin-cpu client
+	;;
 esac
 
 options="--format k -c $remotehost -p $control_port $protocol $length --get-server-output"
+if [ "$omit" -ne 0 ]; then
+    options+=" --omit $omit"
+fi
+
 #options+=" --cport $data_port"
 # strip ',' from the passthru options 
 passthru_opts=$(echo "$pt_opts" | sed 's/,/ /g')
@@ -224,7 +268,7 @@ if [ $bit_rate != None ]; then
 fi
 cmd+="${cpu_pin_cmd} iperf3 $options"
 if [ "$ipv" == "6" ]; then
-    cmd+=" -V"
+    cmd+=" -6"
 fi
 echo "going to run: ${cmd}"
 

--- a/iperf-get-runtime
+++ b/iperf-get-runtime
@@ -1,14 +1,32 @@
 #!/bin/bash
 # vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
 # -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
-duration=3600
-opts=$(getopt -q -o "" --longoptions "duration:" -n "getopt.sh" -- "$@");
+
+#exec >iperf-runtime-stderrout.txt
+#exec 2>&1
+
+#iperf3 default time is 10sec
+time=10
+bitrate_range=""
+pt_opts=""
+opts=$(getopt -q -o "" --longoptions "time:,bitrate-range:,passthru:" -n "getopt.sh" -- "$@");
 eval set -- "$opts";
+#echo after: $opts
 while true; do
     case "$1" in
-        --duration)
+        --time)
             shift
-            duration=$1
+            time=$1
+            shift
+            ;;
+        --bitrate-range)
+            shift
+            bitrate_range=$1
+            shift
+            ;;
+        --passthru)
+            shift
+            pt_opts=$1
             shift
             ;;
         --)
@@ -20,4 +38,35 @@ while true; do
             ;;
     esac
 done
-echo $duration
+
+# If passthru, use passthu time. 
+if [ "$pt_opts" != "" ]; then
+    # If passthru has -t option, it overrides mv-param $time value
+    # strip ',' from the pt_opts string
+    passthru=$(echo "$pt_opts" | sed 's/,/ /g')
+    for p in ${passthru}; do
+        if echo "$p" | grep -Eq '\-t[0-9]'; then
+            time=$(echo $p | sed 's/-t//g')
+            break
+        fi
+    done
+
+elif [ "$bitrate_range" != "" ]; then
+    # 0-drop hunting - time factor is O(log2N)
+    bstart=$(echo $bitrate_range | awk -F'-' '{print $1}')
+    bend=$(echo $bitrate_range | awk -F'-' '{print $2}')
+    # strip the unit letter i.e 10M-4000M
+    bstart=${bstart::-1}
+    bend=${bend::-1}
+    range=$((bend-bstart))
+    # compute log2N of this range
+    log_value=$(echo $range | awk '{printf "%d\n", log($1)/log(2)}')
+    # crude way for get its ceil value
+    log_value=$(($log_value+1))
+    time=$(echo $log_value $time | awk '{printf "%d\n", $1*$2}')
+fi
+
+# Set T/O time 2X the compute time.
+time=$(echo $time | awk '{printf "%d\n", $1*2}')
+echo $time
+

--- a/iperf-hunter
+++ b/iperf-hunter
@@ -94,17 +94,25 @@ function iperf-drop-analyzer {
     #   [  5]   0.00-30.00  sec  17.5 GBytes  5.00 Gbits/sec  0.012 ms  148/1144389 (0.013%)  receiver
     pwd 
     local __tuple
+    local Lost
+    local Total
     rfile="iperf-client-result.txt"
     pattern="receiver"
 
     line=$(tail  -n 5 $rfile | grep $pattern)
     #colum 11 is Lost/Total
     __tuple="$(echo $line | awk '{print $11}')"
-    analyzed_result=$(echo $__tuple | awk -F'/' '{print $1}')
-    if [ $analyzed_result -eq "0" ] ; then
-        echo "PASS: $line" >> iperf-client-result.txt
-    else
+    Lost=$(echo $__tuple | awk -F'/' '{print $1}')
+    Total=$(echo $__tuple | awk -F'/' '{print $2}')
+    if [ $Total -eq "0" ] ; then
         echo "FAIL: $line" >> iperf-client-result.txt
+        analyzed_result=-1
+    elif [ $Lost -ne "0" ] ; then
+        echo "FAIL: $line" >> iperf-client-result.txt
+        analyzed_result=$Lost
+    else
+        echo "PASS: $line" >> iperf-client-result.txt
+        analyzed_result=$Lost
     fi
 }   
 
@@ -119,7 +127,7 @@ function iperf-drop-analyzer {
 function iperf-drop-hunter {
     debug_pr iperf-drop-hunter @116 enter: $@
     new_cmd="$cmd --bitrate $2$1" 
-    debug_pr iperf-drop-hunter @119 new_cmd: $new_cmd
+    echo iperf-drop-hunter @119 new_cmd: $new_cmd
     ${new_cmd} 2>&1 | tee -a iperf-client-result.txt
     iperf-drop-analyzer
     if [ "$analyzed_result" -ne "0" ]; then

--- a/iperf-post-process
+++ b/iperf-post-process
@@ -34,7 +34,8 @@ my $ts;
 my $ts_end;
 my %times;
 my $hunting_mode=0;
-my $omit=2;
+# omit is a utility feature for re post-process and ignore a number of first second drops.
+my $omit=0;
 use constant SEC_TO_MSEC => 1000;
 use constant KBPS_TO_GBPS => 1000000;
 

--- a/iperf-post-process
+++ b/iperf-post-process
@@ -34,10 +34,11 @@ my $ts;
 my $ts_end;
 my %times;
 my $hunting_mode=0;
+my $omit=2;
 use constant SEC_TO_MSEC => 1000;
 use constant KBPS_TO_GBPS => 1000000;
 
-my $debug;
+my $debug=0;
 
 sub debug_print {
     if ( defined $debug ) {
@@ -55,7 +56,8 @@ GetOptions ("remotehost=s" => \$remotehost,
             "bitrate=s" => \$ignore,
             "ifname=s" => \$ignore,
             "cpu-pin=s" => \$ignore,
-            "bitrate-range=s" => \$hunting_mode
+            "bitrate-range=s" => \$hunting_mode,
+            "omit=s" => \$omit
             );
 #
 # Extract begin/end timestamps recorded by the iperf run.
@@ -102,6 +104,16 @@ sub process_proto {
             if ( /SUM/ ) {
                 next;
             }
+
+            if ( /omitted/ ) {
+                #  Skip warm up entries from iperf "--omit" option. 
+                #
+                # [ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
+                # [  5]   0.00-1.00   sec   572 MBytes  4800330 Kbits/sec  0.001 ms  1357/587336 (0.23%)  (omitted)
+                # [  5]   1.00-2.00   sec   580 MBytes  4867703 Kbits/sec  0.001 ms  0/594202 (0%)  (omitted)
+                next;
+            } 
+
             if ( $protocol eq "udp") {
                 # Its output is as follows:
                 #   [ ID] Interval           Transfer     Bitrate         Total Datagrams
@@ -168,6 +180,17 @@ sub process_proto {
                         debug_print("Lost:$lost Total:$total\n");
 
                         %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => 'rx-lost/sec');
+
+                        if ( $omit != 0 ) {
+                            # Special handling for reruning "crucible postprocess" and wanting to 
+                            # skip the first few second drops as though we have run with --omit option
+                            # This is a hack for times when we do not have the testbed to rerun, and just use the
+                            # existing results, but altering the postprocessing to ignore drops of the first few intervals.
+                            if ( $end <= $omit) {
+                                debug_print("fudge lost value due to on-demand omit, line: $_");
+                                $lost=0;
+                            }
+                        }
                         %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' =>  $lost);
                         log_sample("0", \%desc, \%names, \%s);
 

--- a/iperf-server-start
+++ b/iperf-server-start
@@ -199,27 +199,13 @@ echo "ifname=${ifname}"
 echo "ifname_numa_node=${ifname_numa_node}"
 echo "ifname_numa_node_cpus=${ifname_numa_node_cpus}"
 
-function assign-pin-cpu {
-    local my_cpu
-
-    # iperf PIN is to pin same NUMA and 1 CPU
-    IFS=',' read -r -a array <<< "$ifname_numa_node_cpus"
-    if [ "$1" == "client" ]; then
-        my_cpu=${array[${#array[@]}-1]}
-    else
-        my_cpu=${array[${#array[@]}-2]}
-    fi
-    cpu_pin_cmd="taskset --cpu-list ${my_cpu}"
-    echo $1: $cpu_pin_cmd
-}
-
 cpu_pin_cmd=""
 case "${cpu_pin}" in
     "numa")
         cpu_pin_cmd="taskset --cpu-list ${ifname_numa_node_cpus}"
         ;;
     "cpu-numa")
-        assign-pin-cpu server
+        assign-pin-cpu server ${ifname_numa_node_cpus}
         ;;
 esac
 

--- a/iperf-server-start
+++ b/iperf-server-start
@@ -152,7 +152,7 @@ if [ ! -z "$ifname" ]; then
         echo "IP was found: $ip"
     fi
 else
-    echo "Not going to look for an IP since --server-ifname was not used."
+    echo "Not going to look for an IP since --ifname was not used."
 fi
 
 # Queue ip/port info, to be sent to endpoint

--- a/iperf-server-start
+++ b/iperf-server-start
@@ -62,14 +62,14 @@ while true; do
 done
 
 case "${cpu_pin}" in
-    ""|"numa")
+    ""|"numa"|"cpu-numa")
 	;;
     *)
 	exit_error "unsupported cpu-pin value '${cpu_pin}'"
 	;;
 esac
 
- uname -a
+uname -a
 
 # A benchmark server can provide both an IP and ports to the client.
 # The server must package these in a JSON, which will be sent to
@@ -96,18 +96,20 @@ if [ ! -z "$ifname" ]; then
         ifname="${before_var}${var}${after_var}"
     fi
     if [ "${ifname}" == "default-route" ]; then
-	echo "Looking for default route interface..."
-	ip -j route > route.json
-	ifname=$(jq --raw-output 'to_entries | .[] | if (.value.dst == "default") then .value.dev else null end' route.json | grep -v null)
-	if [ -z "${ifname}" ]; then
-	    exit_error "could not find default route interface"
-	else
-	    echo "Found default route on interface ${ifname}"
-	fi
+       echo "Looking for default route interface..."
+       ip -j route > route.json
+       ifname=$(jq --raw-output 'to_entries | .[] | if (.value.dst == "default") then .value.dev else null end' route.json | grep -v null)
+       if [ -z "${ifname}" ]; then
+           exit_error "could not find default route interface"
+       else
+           echo "Found default route on interface ${ifname}"
+       fi
     else
-	echo "--ifname=${ifname} was found"
+       echo "--ifname=${ifname} was found"
     fi
     echo "Searching for IP for interface ${ifname}..."
+
+    echo "--ifname=$ifname was found, searching for IP"
     # Find the element in the 'ip a' array that matches the ifname we are looking for
     ifname_idx=`jq 'to_entries | .[] | if (.value.ifname == "'$ifname'") then .key else null end' ip.json | grep -v null`
     if [ ! -z "$ifname_idx" ]; then
@@ -150,7 +152,7 @@ if [ ! -z "$ifname" ]; then
         echo "IP was found: $ip"
     fi
 else
-    echo "Not going to look for an IP since --ifname was not used."
+    echo "Not going to look for an IP since --server-ifname was not used."
 fi
 
 # Queue ip/port info, to be sent to endpoint
@@ -176,31 +178,55 @@ ss -tlnp
 echo
 #TODO: exit with error if ports still used
 
-ifname_numa_node=-1
-ifname_numa_node_cpus=-1
+ifname_numa_node=
+ifname_numa_node_cpus=
 if [ -e /sys/class/net/${ifname}/device/numa_node ]; then
     ifname_numa_node=$(cat /sys/class/net/${ifname}/device/numa_node)
-
-    ifname_numa_node_cpus=$(cat /sys/devices/system/node/node${ifname_numa_node}/cpulist)
-elif [ "${cpu_pin}" == "numa" ]; then
-    exit_error "cannot determine numa node for interface '${ifname}' and cpu-pin is numa"
+    if [ "$ifname_numa_node" == "-1" ]; then
+        # VM case, use numa 0
+        ifname_numa_node=0
+    fi
+else
+    # When topo=internode topo, the device is eth0. Default it to numa node0.
+    # In other word, if there is no numa associated with ifname, just use numa 0
+    ifname_numa_node=0
 fi
 
+ifname_numa_node_cpus=$(cat /sys/devices/system/node/node${ifname_numa_node}/cpulist)
+# convert to comma separated list if there are ranges i.e 0-5 items
+ifname_numa_node_cpus=$(echo $ifname_numa_node_cpus | perl -pe 's/(\d+)-(\d+)/join(",",$1..$2)/eg')
 echo "ifname=${ifname}"
 echo "ifname_numa_node=${ifname_numa_node}"
+echo "ifname_numa_node_cpus=${ifname_numa_node_cpus}"
+
+function assign-pin-cpu {
+    local my_cpu
+
+    # iperf PIN is to pin same NUMA and 1 CPU
+    IFS=',' read -r -a array <<< "$ifname_numa_node_cpus"
+    if [ "$1" == "client" ]; then
+        my_cpu=${array[${#array[@]}-1]}
+    else
+        my_cpu=${array[${#array[@]}-2]}
+    fi
+    cpu_pin_cmd="taskset --cpu-list ${my_cpu}"
+    echo $1: $cpu_pin_cmd
+}
 
 cpu_pin_cmd=""
 case "${cpu_pin}" in
     "numa")
-	cpu_pin_cmd="taskset --cpu-list ${ifname_numa_node_cpus}"
-	;;
+        cpu_pin_cmd="taskset --cpu-list ${ifname_numa_node_cpus}"
+        ;;
+    "cpu-numa")
+        assign-pin-cpu server
+        ;;
 esac
-
 
 passthru_opts=$(echo "$pt_opts" | sed 's/,/ /g')
 cmd="${cpu_pin_cmd} iperf3 -s --format k -p $control_port $passthru_opts"
 if [ "$ipv" == "6" ]; then
-    cmd+=" -V"
+    cmd+=" -6"
 fi
 echo "going to run: $cmd"
 export MALLOC_CHECK_=2

--- a/multiplex.json
+++ b/multiplex.json
@@ -19,7 +19,7 @@
         },
         "positive_integer": {
             "description": "a whole number greater than 0",
-            "args": [ "length", "time" ],
+            "args": [ "length", "time", "omit" ],
             "vals": "[1-9][0-9]*"
         },
         "bitrate": {
@@ -45,7 +45,7 @@
 	    "cpu-pinning": {
 	        "description": "valid cpu pinning modes",
 	        "args": [ "cpu-pin" ],
-	        "vals": "^numa$"
+	        "vals": "^numa$|^cpu-numa$"
 	    },
         "size_KMG_range" : {
             "description" : "a range of size_KMG",


### PR DESCRIPTION
Description: 
This commit contains miscellaneous tweaks:
+ omit: a special postprocessing option to ignore first few seconds worth of results as warm-up period.
+ cpu-numa: option to pin client and server to same NUMA if possible, but owned CPU
+ runtime: compute runtime according to 'time' params taken 0-drop hunting iterations into account.