### PR TITLE
Add max UDP tput by drop percentage

### DIFF
--- a/iperf-client
+++ b/iperf-client
@@ -23,10 +23,11 @@ ipv="4"
 bstart=0
 bend=0
 bitrate_range=
+max_loss_pct=0
 omit=0
 
 echo "opts before: $@"
-longopts="ipv:,ifname:,protocol:,length:,remotehost:,time:,bitrate:,cpu-pin:,passthru:,bitrate-range:,omit:"
+longopts="ipv:,ifname:,protocol:,length:,remotehost:,time:,bitrate:,cpu-pin:,passthru:,bitrate-range:,max-loss-pct:,omit:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     exit_error "Unrecognized option specified"
@@ -71,6 +72,12 @@ while true; do
             shift;
             bit_rate=$1
             echo "bitrate=$bit_rate"
+            shift
+            ;;
+        --max-loss-pct)
+            shift;
+            max_loss_pct=$1
+            echo "max-loss-pct=$max-loss-pct"
             shift
             ;;
         --remotehost)
@@ -267,7 +274,7 @@ if [ "$bitrate_range" != "" ]; then
     
     echo "HUNTING begin:" > iperf-client-result.txt
     date +%s.%N >begin.txt
-    generic-hunter --begin $bstart --end $bend iperf-drop-hunter $unit
+    generic-hunter --begin $bstart --end $bend  --max-loss-pct $max_loss_pct iperf-drop-hunter $unit
     date +%s.%N >end.txt
     exit
 fi

--- a/iperf-get-runtime
+++ b/iperf-get-runtime
@@ -50,8 +50,9 @@ if [ "$pt_opts" != "" ]; then
             break
         fi
     done
+fi
 
-elif [ "$bitrate_range" != "" ]; then
+if [ "$bitrate_range" != "" ]; then
     # 0-drop hunting - time factor is O(log2N)
     bstart=$(echo $bitrate_range | awk -F'-' '{print $1}')
     bend=$(echo $bitrate_range | awk -F'-' '{print $2}')

--- a/iperf-hunter
+++ b/iperf-hunter
@@ -7,6 +7,8 @@ function debug_pr {
     fi
 }
 
+max_percent=0
+
 # generic-binary-hunter - binary search the result of a command .
 # Arguments: <low> <high> <cmd>
 # Return: when cmd's return value is 1
@@ -47,7 +49,7 @@ function generic-binary-hunter {
 function generic-hunter {
     debug_pr generic-hunter @45 enter: $@
 
-    longopts="begin:,end:"
+    longopts="begin:,end:,max-loss-pct:"
     opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
     if [ $? -ne 0 ]; then
         exit_error "Unrecognized option specified"
@@ -63,6 +65,11 @@ function generic-hunter {
         --end)
             shift;
             end="$1"
+            shift
+            ;; 
+        --max-loss-pct)
+            shift;
+            max_percent="$1"
             shift
             ;; 
         --)
@@ -99,20 +106,45 @@ function iperf-drop-analyzer {
     rfile="iperf-client-result.txt"
     pattern="receiver"
 
-    line=$(tail  -n 5 $rfile | grep $pattern)
+    #
+    # Note, sender's Total do not match receiver's Total even when iperf says 
+    # 0% drop. iperf3 itself also computes % drop using receiver stats ONLY. 
+    #
+    receiver_line=$(perl -e 'print reverse <>' $rfile | grep -m 1 "receiver")
+    debug_pr receiver_line=$line
+
     #colum 11 is Lost/Total
-    __tuple="$(echo $line | awk '{print $11}')"
+    __tuple="$(echo $receiver_line | awk '{print $11}')"
     Lost=$(echo $__tuple | awk -F'/' '{print $1}')
     Total=$(echo $__tuple | awk -F'/' '{print $2}')
-    if [ $Total -eq "0" ] ; then
-        echo "FAIL: $line" >> iperf-client-result.txt
+
+    if [ "$Total" -eq "0"  ]; then
+        # UDP must have collapsed. No pkt arrived at the receive side.
+        # This could happen when ipfrag was overwhelmed.
+        echo "FAIL: $receiver_line"  >> iperf-client-result.txt
         analyzed_result=-1
-    elif [ $Lost -ne "0" ] ; then
-        echo "FAIL: $line" >> iperf-client-result.txt
-        analyzed_result=$Lost
+    elif [ "$Lost" -eq "0" ] ; then
+        echo "PASS: $receiver_line"  >> iperf-client-result.txt
+        analyzed_result=0
     else
-        echo "PASS: $line" >> iperf-client-result.txt
-        analyzed_result=$Lost
+        # Compare drops against max-drop-pct limit.
+        percent_drop="$(echo $receiver_line | awk '{print $12}')"
+        debug_pr iperf_drop_percent=$percent_drop
+        # percent_drop is what iperf says, but we'd like to calculate it.
+        calc_percent=$(echo $Lost $Total | awk '{print $1*100/$2}')
+        debug_pr calc_percent=$calc_percent  max_percent=$max_percent
+
+        # Use awk for float compare.
+        # The "!" is needed because the logic in awk boolean tests
+        # is the opposite of the one in shell exit code tests
+        if ! awk "BEGIN{ exit ($calc_percent <= $max_percent) }"; then
+            # Drops were less than max-drop-pct. 
+            echo "PASS: $receiver_line" >> iperf-client-result.txt
+            analyzed_result=0
+        else
+            echo "FAIL: $receiver_line"  >> iperf-client-result.txt
+            analyzed_result=$Lost
+        fi
     fi
 }   
 

--- a/iperf-post-process
+++ b/iperf-post-process
@@ -36,6 +36,7 @@ my %times;
 my $hunting_mode=0;
 # omit is a utility feature for re post-process and ignore a number of first second drops.
 my $omit=0;
+my $max_loss_pct=0;
 use constant SEC_TO_MSEC => 1000;
 use constant KBPS_TO_GBPS => 1000000;
 
@@ -55,6 +56,7 @@ GetOptions ("remotehost=s" => \$remotehost,
             "protocol=s" => \$protocol,
             "time=i" => \$ignore,
             "bitrate=s" => \$ignore,
+            "max-loss-pct=s" => \$max_loss_pct,
             "ifname=s" => \$ignore,
             "cpu-pin=s" => \$ignore,
             "bitrate-range=s" => \$hunting_mode,
@@ -346,14 +348,13 @@ sub process_proto {
 #    PASS: [  5]   0.00-10.00  sec   215 MBytes  180272 Kbits/sec  0.001 ms  0/3521093 (0%)  receiver
 #    FAIL: [  5]   0.00-10.00  sec   215 MBytes  190272 Kbits/sec  0.001 ms  20/3521093 (0%)  receiver
 # Ouput from query:
-#      result: (no-drop-highest/Gbps) samples: 0.182000 mean: 0.182000 min: 0.182000 max: 0.182000 stddev: NaN stddevpct: NaN
+#      result: (N percent drop tput/Gbps) samples: 0.182000 mean: 0.182000 min: 0.182000 max: 0.182000 stddev: NaN stddevpct: NaN
 #
 use POSIX;
 sub process_hunting_results {
-
-    my $bitrate;
     my $highest_bitrate=0;
-    my $lowest_bitrate=POSIX::ULONG_MAX;
+    my $bitrate=0;
+    #my $lowest_bitrate=POSIX::ULONG_MAX;
     print "process_hunting_results: enter\n";
 
     (my $rc, my $fh) = open_read_text_file($result_file);
@@ -367,35 +368,21 @@ sub process_hunting_results {
                 # PASS: [  5]   0.00-10.00  sec   215 MBytes  180272 Kbits/sec  0.001 ms  0/3521093 (0%)  receiver
                 my @columns = split(/\s+/, $_);
                 $bitrate=$columns[7];
-
                 if ($bitrate > $highest_bitrate) {
                     $highest_bitrate=$bitrate;
                 }
                 next;
 
             }
-            if ( /FAIL/ ) {
-                # FAIL: [  5]   0.00-10.00  sec   215 MBytes  180272 Kbits/sec  0.001 ms  20/3521093 (0.01%)  receiver
-                my @columns = split(/\s+/, $_);
-                $bitrate=$columns[7];
-                if ($bitrate < $lowest_bitrate) {
-                    $lowest_bitrate=$bitrate;
-                }
-                next;
-            }
         }
         close($fh);
         $highest_bitrate= $highest_bitrate / KBPS_TO_GBPS;
-        $lowest_bitrate = $lowest_bitrate  / KBPS_TO_GBPS;
 
-        %desc = ('source' => 'iperf', 'class' => 'count', 'type' => 'no-drop-highest/Gbps');
+        %desc = ('source' => 'iperf', 'class' => 'count', 'type' => "$max_loss_pct percent drop tput/Gbps");
         %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' =>  $highest_bitrate);
         log_sample("0", \%desc, \%names, \%s);
 
-        %desc = ('source' => 'iperf', 'class' => 'count', 'type' => 'drop-lowest/Gbps');
-        %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' =>  $lowest_bitrate);
-        log_sample("0", \%desc, \%names, \%s);
-        $primary_metric = "no-drop-highest/Gbps";
+        $primary_metric = "$max_loss_pct percent drop tput/Gbps";
 
         my $metric_data_name = finish_samples(1);
         # Associate the metrics with a benchmark-period (in this case "measurement")
@@ -419,7 +406,7 @@ sub process_hunting_results {
         printf "Is the current directory for a iperf server (no result file)?\n";
     }
 
-    printf("hi-no-drop=%.3f Gbps, low-drop=%.3f Gbps\n", $highest_bitrate, $lowest_bitrate);
+    printf("$max_loss_pct percent drop TPUT=%.3f Gbps\n", $highest_bitrate);
 }
 
 if ($hunting_mode eq 0) {

--- a/multiplex.json
+++ b/multiplex.json
@@ -27,6 +27,11 @@
             "args": [ "bitrate" ],
             "vals": "[0-9]*[GMKgmk]*"
         },
+        "positive_float": {
+            "description": "any positive floating point value",
+            "args": [ "max-loss-pct" ],
+            "vals": [ "^([1-9][0-9]*\\.?[0-9]*)|(0?\\.[0-9]+)|(0)$" ]
+        },
         "host-or-ip": {
             "description" : "a hostname or IP address",
             "args": [ "remotehost" ],


### PR DESCRIPTION
**Description**: This commit adds "UDP throughput by drop percentage" to drop hunter feature. Piggyback to the commit are a few misc cleanup.
**Solution:**
- Add 'max-loss-pct' params. i.e { "arg": "max-loss-pct", "vals": ["0.1"], "role": "client" }. 
- Drop hunter infra uses the new 'max-loss-pct' in per run PASS/FAIL determination. 

``
        result: (0.1 percent drop tput/Gbps) samples: 0.406200 mean: 0.406200 min: 0.406200 max: 0.406200 stddev: NaN stddevpct: NaN
``                                                                                                                                     

**Miscellaneous:**
- Removed 'drop-lowest/Gbps' metric which was an obsolete debug metric
- Hunting time also supports passthru "--time"