### PR TITLE
Change hunter's primary type to "rx-Gbps", and add rx-pps metric to hunter also

### DIFF
--- a/iperf-client
+++ b/iperf-client
@@ -273,15 +273,13 @@ if [ "$bitrate_range" != "" ]; then
     bend=${bend::-1}
     
     echo "HUNTING begin:" > iperf-client-result.txt
-    date +%s.%N >begin.txt
     generic-hunter --begin $bstart --end $bend  --max-loss-pct $max_loss_pct iperf-drop-hunter $unit
-    date +%s.%N >end.txt
     exit
 fi
 
-date +%s.%N >begin.txt
-${cmd} 2>&1 >iperf-client-result.txt
-date +%s.%N >end.txt
+echo BEGIN-TS-0 $(date +%s.%N) > iperf-client-result.txt
+${cmd} 2>&1 >> iperf-client-result.txt
+echo END-TS-0 $(date +%s.%N) >> iperf-client-result.txt
 iperf_rc=$?
 if [ $iperf_rc -gt 0 ]; then
     iperf_errors=`grep -i error iperf-client-result.txt`

--- a/iperf-hunter
+++ b/iperf-hunter
@@ -8,6 +8,7 @@ function debug_pr {
 }
 
 max_percent=0
+h_iter=0
 
 # generic-binary-hunter - binary search the result of a command .
 # Arguments: <low> <high> <cmd>
@@ -20,6 +21,7 @@ function generic-binary-hunter {
     local high=$2
     shift 2
 
+    h_iter=$((h_iter+1))
     if [ $low -gt $(($high - 2)) ]; then
         echo Final answer: $low
         return   # final result
@@ -160,7 +162,9 @@ function iperf-drop-hunter {
     debug_pr iperf-drop-hunter @116 enter: $@
     new_cmd="$cmd --bitrate $2$1" 
     echo iperf-drop-hunter @119 new_cmd: $new_cmd
+    echo BEGIN-TS-$h_iter $(date +%s.%N) >> iperf-client-result.txt
     ${new_cmd} 2>&1 | tee -a iperf-client-result.txt
+    echo END-TS-$h_iter $(date +%s.%N) >> iperf-client-result.txt
     iperf-drop-analyzer
     if [ "$analyzed_result" -ne "0" ]; then
         debug_pr @125 drop=$__result FAIL

--- a/iperf-post-process
+++ b/iperf-post-process
@@ -33,6 +33,7 @@ my %s;
 my $ts;
 my $ts_end;
 my %times;
+my $duration;
 my $hunting_mode=0;
 # omit is a utility feature for re post-process and ignore a number of first second drops.
 my $omit=0;
@@ -54,7 +55,7 @@ GetOptions ("remotehost=s" => \$remotehost,
             "length=s" => \$ignore,
             "passthru=s" => \$ignore,
             "protocol=s" => \$protocol,
-            "time=i" => \$ignore,
+            "time=i" => \$duration,
             "bitrate=s" => \$ignore,
             "max-loss-pct=s" => \$max_loss_pct,
             "ifname=s" => \$ignore,
@@ -348,13 +349,15 @@ sub process_proto {
 #    PASS: [  5]   0.00-10.00  sec   215 MBytes  180272 Kbits/sec  0.001 ms  0/3521093 (0%)  receiver
 #    FAIL: [  5]   0.00-10.00  sec   215 MBytes  190272 Kbits/sec  0.001 ms  20/3521093 (0%)  receiver
 # Ouput from query:
-#      result: (N percent drop tput/Gbps) samples: 0.182000 mean: 0.182000 min: 0.182000 max: 0.182000 stddev: NaN stddevpct: NaN
+#      result: (rx-Gbps) samples: 0.182000 mean: 0.182000 min: 0.182000 max: 0.182000 stddev: NaN stddevpct: NaN
 #
 use POSIX;
 sub process_hunting_results {
     my $highest_bitrate=0;
+    my $lost_total;
+    my $total_pps=0;
+    my $avg_pps=0;
     my $bitrate=0;
-    #my $lowest_bitrate=POSIX::ULONG_MAX;
     print "process_hunting_results: enter\n";
 
     (my $rc, my $fh) = open_read_text_file($result_file);
@@ -363,6 +366,10 @@ sub process_hunting_results {
         $ts_end=$times{'end'};
 
         while (<$fh>) {
+            #
+            # Note for hunter we do not process time series data, but process the final line of 
+            # the highest/best run. The "PASS: ... receiver" line.
+            #
             debug_print("Proc line: $_"); 
             if ( /PASS/ ) {
                 # PASS: [  5]   0.00-10.00  sec   215 MBytes  180272 Kbits/sec  0.001 ms  0/3521093 (0%)  receiver
@@ -370,6 +377,9 @@ sub process_hunting_results {
                 $bitrate=$columns[7];
                 if ($bitrate > $highest_bitrate) {
                     $highest_bitrate=$bitrate;
+                    $lost_total=$columns[11];
+                    my @tuple = split /\//, $lost_total;
+                    $total_pps = $tuple[1];
                 }
                 next;
 
@@ -377,12 +387,16 @@ sub process_hunting_results {
         }
         close($fh);
         $highest_bitrate= $highest_bitrate / KBPS_TO_GBPS;
+        $avg_pps = $total_pps/$duration;
 
-        %desc = ('source' => 'iperf', 'class' => 'count', 'type' => "$max_loss_pct percent drop tput/Gbps");
+        %desc = ('source' => 'iperf', 'class' => 'count', 'type' => "rx-Gbps");
         %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' =>  $highest_bitrate);
         log_sample("0", \%desc, \%names, \%s);
+        $primary_metric = "rx-Gbps";
 
-        $primary_metric = "$max_loss_pct percent drop tput/Gbps";
+        %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => 'rx-pps');
+        %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' => $avg_pps);
+        log_sample("0", \%desc, \%names, \%s);
 
         my $metric_data_name = finish_samples(1);
         # Associate the metrics with a benchmark-period (in this case "measurement")

--- a/iperf-post-process
+++ b/iperf-post-process
@@ -27,6 +27,7 @@ my $ignore;
     # So we will init primary_metric when we examine the outputs.
 my $primary_metric;
 my $result_file = "iperf-client-result.txt";
+my $final_hunt_result = "hunt-temp-result.txt";
 my %names = ('cmd' => 'write');
 my %desc;
 my %s;
@@ -41,7 +42,7 @@ my $max_loss_pct=0;
 use constant SEC_TO_MSEC => 1000;
 use constant KBPS_TO_GBPS => 1000000;
 
-my $debug=0;
+my $debug;
 
 sub debug_print {
     if ( defined $debug ) {
@@ -63,15 +64,6 @@ GetOptions ("remotehost=s" => \$remotehost,
             "bitrate-range=s" => \$hunting_mode,
             "omit=s" => \$omit
             );
-#
-# Extract begin/end timestamps recorded by the iperf run.
-#
-foreach my $i (qw(begin end)) {
-    my $file = $i . ".txt";
-    open(FH, $file) || die "Could not open " . $file;
-    $times{$i} = int (<FH> * SEC_TO_MSEC);
-    close FH; 
-}
 
 #
 # process_proto - supports TCP and UDP.
@@ -84,6 +76,7 @@ foreach my $i (qw(begin end)) {
 # Note: the interval of time-series is configurable by "--interval" option. So we compute it.
 #
 sub process_proto {
+    my $data_file = $_[0];
     my $bitrate;
     my $bitrate_div;
     my $interval;
@@ -91,7 +84,7 @@ sub process_proto {
     my $rateunit='none';
     my $sample_count=0;
 
-    (my $rc, my $fh) = open_read_text_file($result_file);
+    (my $rc, my $fh) = open_read_text_file($data_file);
     if ($rc == 0 and defined $fh) {
         $ts=$times{'begin'};
 
@@ -196,6 +189,7 @@ sub process_proto {
                             }
                         }
                         %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' =>  $lost);
+                        debug_print("log_sample: lost=$lost\n");
                         log_sample("0", \%desc, \%names, \%s);
 
                         %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => 'rx-pps');
@@ -207,6 +201,7 @@ sub process_proto {
                             $primary_metric = "rx-Gbps";
                             debug_print("primary_metric $primary_metric\n");
                         }
+                        debug_print("log_sample: primary_metric=$primary_metric\n");
                         %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => $primary_metric);
 
                     } else {
@@ -216,7 +211,7 @@ sub process_proto {
 
                     # log rx "bitrate" sample
                     %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' => ($bitrate / $bitrate_div));
-                    print ("begin: int $ts, end: int $ts_end\n");
+                    debug_print ("begin: int $ts, end: int $ts_end\n");
                     log_sample("0", \%desc, \%names, \%s);
                     $sample_count++;
                     $ts=$ts+$interval;
@@ -342,34 +337,52 @@ sub process_proto {
     }
 } 
 
+
 #
-# process_hunting_results - processes results of zero-drop hunting runs.
-#    This function indexes the highest PASS and the lowest FAIL results.
-# Inputs: the line patterns that will be processed.
-#    PASS: [  5]   0.00-10.00  sec   215 MBytes  180272 Kbits/sec  0.001 ms  0/3521093 (0%)  receiver
-#    FAIL: [  5]   0.00-10.00  sec   215 MBytes  190272 Kbits/sec  0.001 ms  20/3521093 (0%)  receiver
-# Ouput from query:
-#      result: (rx-Gbps) samples: 0.182000 mean: 0.182000 min: 0.182000 max: 0.182000 stddev: NaN stddevpct: NaN
+# dup_one_run - Copy a section of a file to a new file
+#
+# Argument $_[0]: filehandle, pointing to start position for copying.
+# Argument $_[1]: a line that the caller wants to be put on top of the new file.
+# Argument $_[3]: the name of the new file.
+#
+sub dup_one_run {
+    my $ifh  = $_[0];
+    my $first_line  = $_[1];
+    my $outfile  = $_[2];
+
+    open my $ofh, '>', $outfile or die "$outfile: $!";
+    print $ofh $first_line;
+    while (<$ifh>) {
+        #printf("extraxt line: $_"); 
+        print $ofh $_;
+        last if /END-TS/;
+    }
+    close $ofh;
+}
+
+#
+# pre_process_hunting_results - Isolates the highest PASS result to a temp file.
+#
+# Argument $_[0]: the name of the src_file
+# Argument $_[1]: the name of the dest_file
 #
 use POSIX;
-sub process_hunting_results {
+sub pre_process_hunting_results {
+    my $from_file= $_[0];
+    my $to_file= $_[1];;
     my $highest_bitrate=0;
-    my $lost_total;
-    my $total_pps=0;
-    my $avg_pps=0;
-    my $bitrate=0;
-    print "process_hunting_results: enter\n";
+    my $bitrate= 0;
+    my $highest_run_number=0;
+    my $cur_run_number=0;
+    debug_print("process_hunting_results: enter\n");
 
-    (my $rc, my $fh) = open_read_text_file($result_file);
+    (my $rc, my $fh) = open_read_text_file($from_file);
+    # scan the big report and find the highest PASS
     if ($rc == 0 and defined $fh) {
-        $ts=$times{'begin'};
-        $ts_end=$times{'end'};
-
         while (<$fh>) {
-            #
-            # Note for hunter we do not process time series data, but process the final line of 
-            # the highest/best run. The "PASS: ... receiver" line.
-            #
+            if ( /BEGIN-TS/ ) {
+                $cur_run_number++;
+            }
             debug_print("Proc line: $_"); 
             if ( /PASS/ ) {
                 # PASS: [  5]   0.00-10.00  sec   215 MBytes  180272 Kbits/sec  0.001 ms  0/3521093 (0%)  receiver
@@ -377,56 +390,56 @@ sub process_hunting_results {
                 $bitrate=$columns[7];
                 if ($bitrate > $highest_bitrate) {
                     $highest_bitrate=$bitrate;
-                    $lost_total=$columns[11];
-                    my @tuple = split /\//, $lost_total;
-                    $total_pps = $tuple[1];
+                    $highest_run_number=$cur_run_number;
                 }
                 next;
-
             }
         }
-        close($fh);
-        $highest_bitrate= $highest_bitrate / KBPS_TO_GBPS;
-        $avg_pps = $total_pps/$duration;
-
-        %desc = ('source' => 'iperf', 'class' => 'count', 'type' => "rx-Gbps");
-        %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' =>  $highest_bitrate);
-        log_sample("0", \%desc, \%names, \%s);
-        $primary_metric = "rx-Gbps";
-
-        %desc = ('source' => 'iperf', 'class' => 'throughput', 'type' => 'rx-pps');
-        %s = ('begin' => int $ts, 'end' => int $ts_end, 'value' => $avg_pps);
-        log_sample("0", \%desc, \%names, \%s);
-
-        my $metric_data_name = finish_samples(1);
-        # Associate the metrics with a benchmark-period (in this case "measurement")
-        my %sample;
-        my @periods;
-        my %period = ('name' => 'measurement');
-        $sample{'rickshaw-bench-metric'}{'schema'}{'version'} = "2021.04.12";
-        my @metric_files = ( $metric_data_name );
-        $period{'metric-files'} = \@metric_files;
-        push(@periods, \%period);
-        $sample{'periods'} = \@periods;
-        $sample{'primary-period'} = 'measurement';
-        $sample{'primary-metric'} = $primary_metric;
-        $rc = put_json_file("post-process-data.json", \%sample);
-        if ($rc > 0) {
-            printf "iperf-post-process(): Could not write file post-process-data.json\n";
-            exit 1
-        }
-    } else {
-        printf "iperf-post-process(): open_read_text_file() failed with return code %d for file %s\n", $rc, $result_file;
-        printf "Is the current directory for a iperf server (no result file)?\n";
     }
+    close($fh);
+    printf ("Highest run num = %d\n", $highest_run_number);
 
-    printf("$max_loss_pct percent drop TPUT=%.3f Gbps\n", $highest_bitrate);
+    # DUP the highest PASS content to a temp file 
+    ($rc, $fh) = open_read_text_file($from_file);
+    $cur_run_number=0;
+    while (<$fh>) {
+        if ( /BEGIN-TS/ ) {
+            $cur_run_number++;
+            if ( $highest_run_number == $cur_run_number) {
+                # This is first line of the highest run
+                # Include this current line $_ in the temp file also
+                dup_one_run($fh, $_, $to_file);
+                last;
+            }
+        }
+    }
+    close($fh);
+}
+
+# Main
+# Compatibility issue:
+#    Older iperf runs generated time stamps in begin.txt and end.txt files.
+#    Current iperf runs insert time stamps directly into iperf-client-result.txt file.
+#    Older runs lack individual timestamps per hunter iteration also. Those hunter results were 1-sample.
+#
+# Hence, to rerun "crucible postprocess" on older results, use older iperf-post-process version.
+# commit b7bbbca50e1f4bb395e97b1c62ed2c7226bb3485 (HEAD -> main, upstream/main, origin/main, origin/HEAD)
+#
+if ( -e "./begin.txt" ) {
+    printf("Cannot process old results with this version. Please use an older bench-iperf version such as, \n");
+    printf("commit b7bbbca50e1f4bb395e97b1c62ed2c7226bb3485 (HEAD -> main, upstream/main, origin/main, origin/HEAD)\n");
+    exit 1;
 }
 
 if ($hunting_mode eq 0) {
-    process_proto();
+    $times{'begin'} = `grep BEGIN-TS $result_file | awk '{print \$2}'` * SEC_TO_MSEC;
+    $times{'end'}   = `grep END-TS   $result_file | awk '{print \$2}'` * SEC_TO_MSEC;
+    process_proto($result_file);
 } else {
-    process_hunting_results();
+    pre_process_hunting_results($result_file, $final_hunt_result);
+    $times{'begin'} = `grep BEGIN-TS $final_hunt_result | awk '{print \$2}'` * SEC_TO_MSEC;
+    $times{'end'}   = `grep END-TS   $final_hunt_result | awk '{print \$2}'` * SEC_TO_MSEC;
+    process_proto($final_hunt_result);
 }
 
 # EOF


### PR DESCRIPTION
Description:
Originally this PR means to change the hunter primary-metric text from "number percent rx tput/Gbps" to "rx-Gbps, and enable rx-pps.  The last push also enhances hunter run to index the final/best run time-series data fully.

Output:
    iteration-id: 614A3F48-241E-11ED-AC5D-DE4EFB6639B4
      unique params: max-loss-pct=0.1 
      primary-period name: measurement
      ...
        result: (rx-Gbps) samples: 0.406200 mean: 0.406200 min: 0.406200 max: 0.406200 stddev: NaN stddevpct: NaN

[root@dhcp31-72 1]# c get metric --source iperf --type rx-pps --period 617D74DA-241E-11ED-8FBF-DE4EFB6639B4
  "name": "iperf",
  "type": "rx-pps",
  "label": "",
  "values": {
    "": [
      {
        "begin": 1661117070138,
        "end": 1661117097276,
        "value": "1.984e+5"
      }
    ]
 