### PR TITLE
Update iperf-client to abort for benchmark errors

### DIFF
--- a/iperf-client
+++ b/iperf-client
@@ -279,8 +279,8 @@ fi
 
 echo BEGIN-TS-0 $(date +%s.%N) > iperf-client-result.txt
 ${cmd} 2>&1 >> iperf-client-result.txt
-echo END-TS-0 $(date +%s.%N) >> iperf-client-result.txt
 iperf_rc=$?
+echo END-TS-0 $(date +%s.%N) >> iperf-client-result.txt
 if [ $iperf_rc -gt 0 ]; then
     iperf_errors=`grep -i error iperf-client-result.txt`
     exit_error "$iperf_errors"


### PR DESCRIPTION
Addresses issue #33 (crucible does not catch iperf3 error). 