### PR TITLE
feat:  add bidirectional mode (--bidir), and multi iperf engines /Pod with IRQ load sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Claude Code working directory
+.claude/
+
+# Python
+__pycache__/
+*.py[cod]
+*.so
+.Python
+
+# Virtual environments
+venv/
+env/
+ENV/
+
+# Testing artifacts (root directory only, not test-data/)
+/*.csv.xz
+/*.json.xz
+/metric-data-*.csv
+/metric-data-*.json
+/post-process-data.json
+/iperf-client-result.txt
+/iperf-server-result.txt
+
+# Backup files
+*.backup
+*.swp
+*.swo
+*~
+
+# Development/debugging
+JUNK/
+PIN

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,8 @@
 Scripts and configuration to run the iperf3 network throughput benchmark within the crucible framework. Measures TCP/UDP bandwidth between client and server endpoints.
 
 ## Language
-Bash — all scripts
+- Bash for benchmark execution scripts
+- Python for post-processing (`iperf-post-process.py`)
 
 ## Key Files
 | File | Purpose |
@@ -12,9 +13,47 @@ Bash — all scripts
 | `rickshaw.json` | Rickshaw integration: client/server scripts, parameter transformations |
 | `iperf-client` | Client-side benchmark execution |
 | `iperf-server-start` / `iperf-server-stop` | Server lifecycle management |
-| `iperf-post-process` | Parses iperf JSON output into crucible metrics |
+| `iperf-post-process.py` | Parses iperf text output into crucible metrics |
 | `workshop.json` | Engine image build requirements |
+
+## Post-Processing Architecture
+
+### Protocol Detection
+`iperf-post-process.py` automatically detects TCP vs UDP mode from iperf header output:
+- **TCP mode**: Header contains "Retr" column (`has_retr_column = True`)
+- **UDP receiver**: Header contains "Lost/Total" column (`has_lost_total_column = True`)
+- **UDP sender**: Header has neither special column
+
+The `--protocol` parameter is accepted for backward compatibility but ignored — protocol is always auto-detected.
+
+### Pattern-Based Parsing
+The post-processor uses pattern-based parsing instead of fixed column indices to handle varying iperf output formats:
+- **Intervals**: Searches for `X.XX-Y.YY` pattern in any column
+- **Bitrate**: Finds number immediately before `bits/sec` marker
+- **Retries** (TCP): Finds first integer after `bits/sec` marker
+- **Lost/Total** (UDP): Searches for `X/Y` pattern (not containing `bits/sec`)
+
+This approach is robust against:
+- Multi-word column headers that split differently than data
+- Different iperf versions with varying output formats
+- Localized output with different column spacing
+
+### Metrics Collected
+**TCP:**
+- `tx-Gbps` (transmit throughput)
+- `rx-Gbps` (receive throughput, for bidirectional)
+- `tx-retry/sec` (retransmissions per second, when present)
+
+**UDP:**
+- `tx-Gbps` (sender throughput)
+- `rx-Gbps` (receiver throughput)
+- `rx-lost/sec` (receiver packet loss)
+- `rx-pps` (receiver packets per second)
+
+### Bidirectional Mode
+Detected automatically when iperf output contains role markers like `[TX-C]`, `[RX-C]`, `[TX-S]`, `[RX-S]`. TX and RX samples are accumulated separately and logged with appropriate metric types.
 
 ## Conventions
 - Primary branch is `main`
 - Standard Bash modelines and 4-space indentation
+- Python code follows 4-space indentation with standard modelines

--- a/IPERF-OUTPUT-FORMATS.md
+++ b/IPERF-OUTPUT-FORMATS.md
@@ -1,0 +1,203 @@
+# iperf3 Output Formats
+
+This document describes the different output formats produced by iperf3 that the post-processor must handle.
+
+## 1. Unidirectional TCP (Single Direction)
+
+### Raw Output Format
+```
+BEGIN-TS-0 1779369780.139730093
+Connecting to host 172.30.62.103, port 30002
+[  5] local 10.131.0.14 port 46352 connected to 172.30.62.103 port 30002
+[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5]   0.00-1.00   sec  59.6 MBytes  499614 Kbits/sec    0    165 KBytes       (omitted)
+[  5]   1.00-2.00   sec  59.6 MBytes  499909 Kbits/sec    0    165 KBytes       (omitted)
+[  5]   2.00-3.00   sec  59.6 MBytes  500171 Kbits/sec    0    165 KBytes       (omitted)
+[  5]   0.00-1.00   sec  59.6 MBytes  499905 Kbits/sec    0    165 KBytes
+[  5]   1.00-2.00   sec  59.6 MBytes  499909 Kbits/sec    0    165 KBytes
+[  5]   2.00-3.00   sec  59.6 MBytes  500171 Kbits/sec    0    165 KBytes
+[  5]   3.00-4.00   sec  59.6 MBytes  499908 Kbits/sec    0    165 KBytes
+[  5]   4.00-5.00   sec  59.6 MBytes  500171 Kbits/sec    0    165 KBytes
+[  5]   5.00-6.00   sec  59.6 MBytes  499902 Kbits/sec    0    165 KBytes
+[  5]   6.00-7.00   sec  59.6 MBytes  499915 Kbits/sec    0    165 KBytes
+[  5]   7.00-8.00   sec  59.6 MBytes  500171 Kbits/sec    0    165 KBytes
+[  5]   8.00-9.00   sec  59.6 MBytes  499909 Kbits/sec    0    165 KBytes
+[  5]   9.00-10.00  sec  59.6 MBytes  499903 Kbits/sec    0    165 KBytes
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Retr
+[  5]   0.00-10.00  sec   596 MBytes  499989 Kbits/sec    0             sender
+[  5]   0.00-10.00  sec   596 MBytes  499980 Kbits/sec                  receiver
+
+iperf Done.
+END-TS-0 1779369793.147085601
+```
+
+### Format Characteristics
+- **Header**: `[ ID] Interval           Transfer     Bitrate         Retr  Cwnd`
+- **NO** `[Role]` column
+- **Column Positions**:
+  - `columns[0]`: ID (e.g., `[  5]`)
+  - `columns[1]`: (empty/whitespace)
+  - `columns[2]`: Interval (e.g., `0.00-1.00`)
+  - `columns[3]`: "sec"
+  - `columns[4]`: Transfer amount (e.g., `59.6`)
+  - `columns[5]`: Transfer unit (e.g., `MBytes`)
+  - `columns[6]`: Bitrate value (e.g., `499614`)
+  - `columns[7]`: Bitrate unit (e.g., `Kbits/sec`)
+  - `columns[8]`: Retry count (e.g., `0`) - TX only
+  - `columns[9]`: Cwnd value - TX only
+  - `columns[10]`: Cwnd unit - TX only
+
+### Data Line Types
+1. **TX (Transmit) lines**: Have retry and Cwnd fields (num_fields > 8)
+2. **RX (Receive) lines**: No retry/Cwnd fields (num_fields <= 8)
+3. **Omitted lines**: Contain `(omitted)` - should be skipped
+4. **Summary lines**: Contain `sender` or `receiver` - should be skipped
+
+### Processing Requirements
+- Skip lines with `(omitted)`
+- Skip lines with `sender` or `receiver`
+- Skip lines with `SUM`
+- Parse interval from `columns[2]` (e.g., "0.00-1.00" → start=0.00, end=1.00, interval=1000ms)
+- Parse bitrate from `columns[6]` and unit from `columns[7]`
+- If num_fields > 8: it's TX, parse retry from `columns[8]`
+- Use running timestamp that increments by interval duration
+- Reset timestamp when hitting summary lines (for server output section)
+
+### Expected Output
+- For 10-second test with --omit=3:
+  - 3 omitted samples (skipped)
+  - 7 actual samples logged
+- Each sample logged immediately as separate metric
+- Metric types: `tx-Gbps` (for TX lines), `rx-Gbps` (for RX lines), `tx-retry/sec`
+
+---
+
+## 2. Bidirectional TCP (--bidir flag)
+
+### Raw Output Format
+```
+BEGIN-TS-0 1779210504.645399704
+Connecting to host 172.30.144.224, port 30002
+[  5] local 10.131.0.125 port 46792 connected to 172.30.144.224 port 30002
+[  7] local 10.131.0.125 port 46798 connected to 172.30.144.224 port 30002
+[ ID][Role] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5][TX-C]   0.00-1.00   sec  59.6 MBytes  499619 Kbits/sec    1    147 KBytes       (omitted)
+[  7][RX-C]   0.00-1.00   sec  59.6 MBytes  499613 Kbits/sec                  (omitted)
+[  5][TX-C]   1.00-2.00   sec  59.6 MBytes  499908 Kbits/sec    0    147 KBytes       (omitted)
+[  7][RX-C]   1.00-2.00   sec  59.6 MBytes  499912 Kbits/sec                  (omitted)
+[  5][TX-C]   2.00-3.00   sec  59.6 MBytes  500171 Kbits/sec    0    147 KBytes       (omitted)
+[  7][RX-C]   2.00-3.00   sec  59.6 MBytes  500170 Kbits/sec                  (omitted)
+[  5][TX-C]   0.00-1.00   sec  59.6 MBytes  499906 Kbits/sec    0    151 KBytes
+[  7][RX-C]   0.00-1.00   sec  59.6 MBytes  499906 Kbits/sec
+[  5][TX-C]   1.00-2.00   sec  59.6 MBytes  499909 Kbits/sec    0    151 KBytes
+[  7][RX-C]   1.00-2.00   sec  59.6 MBytes  499909 Kbits/sec
+[  5][TX-C]   2.00-3.00   sec  59.6 MBytes  500171 Kbits/sec    0    155 KBytes
+[  7][RX-C]   2.00-3.00   sec  59.6 MBytes  500171 Kbits/sec
+[  5][TX-C]   3.00-4.00   sec  59.5 MBytes  498764 Kbits/sec    0    155 KBytes
+[  7][RX-C]   3.00-4.00   sec  59.5 MBytes  499026 Kbits/sec
+[  5][TX-C]   4.00-5.00   sec  59.8 MBytes  501316 Kbits/sec    0    158 KBytes
+[  7][RX-C]   4.00-5.00   sec  59.7 MBytes  501053 Kbits/sec
+[  5][TX-C]   5.00-6.00   sec  59.6 MBytes  499908 Kbits/sec    0    158 KBytes
+[  7][RX-C]   5.00-6.00   sec  59.6 MBytes  499908 Kbits/sec
+[  5][TX-C]   6.00-7.00   sec  59.6 MBytes  499909 Kbits/sec    0    158 KBytes
+[  7][RX-C]   6.00-7.00   sec  59.6 MBytes  499910 Kbits/sec
+[  5][TX-C]   7.00-8.00   sec  59.6 MBytes  500171 Kbits/sec    0    162 KBytes
+[  7][RX-C]   7.00-8.00   sec  59.6 MBytes  500171 Kbits/sec
+[  5][TX-C]   8.00-9.00   sec  59.6 MBytes  499909 Kbits/sec    0    162 KBytes
+[  7][RX-C]   8.00-9.00   sec  59.6 MBytes  499909 Kbits/sec
+[  5][TX-C]   9.00-10.00  sec  59.6 MBytes  499907 Kbits/sec    0    162 KBytes
+[  7][RX-C]   9.00-10.00  sec  59.6 MBytes  499907 Kbits/sec
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID][Role] Interval           Transfer     Bitrate         Retr
+[  5][TX-C]   0.00-10.00  sec   596 MBytes  499988 Kbits/sec    0             sender
+[  5][TX-C]   0.00-10.00  sec   596 MBytes  499977 Kbits/sec                  receiver
+
+Server output:
+Accepted connection from 10.131.0.125, port 46786
+[  5] local 10.128.2.173 port 30002 connected to 10.131.0.125 port 46792
+[  8] local 10.128.2.173 port 30002 connected to 10.131.0.125 port 46798
+[ ID][Role] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5][RX-S]   0.00-1.00   sec  59.6 MBytes  499618 Kbits/sec                  (omitted)
+[  8][TX-S]   0.00-1.00   sec  59.6 MBytes  499612 Kbits/sec    1    158 KBytes       (omitted)
+[  5][RX-S]   1.00-2.00   sec  59.6 MBytes  499908 Kbits/sec                  (omitted)
+[  8][TX-S]   1.00-2.00   sec  59.6 MBytes  499913 Kbits/sec    0    158 KBytes       (omitted)
+[  5][RX-S]   2.00-3.00   sec  59.6 MBytes  500171 Kbits/sec                  (omitted)
+[  8][TX-S]   2.00-3.00   sec  59.6 MBytes  500171 Kbits/sec    0    162 KBytes       (omitted)
+[  5][RX-S]   0.00-1.00   sec  59.6 MBytes  499904 Kbits/sec
+[  8][TX-S]   0.00-1.00   sec  59.6 MBytes  499904 Kbits/sec    0    162 KBytes
+[  5][RX-S]   1.00-2.00   sec  59.6 MBytes  499909 Kbits/sec
+[  8][TX-S]   1.00-2.00   sec  59.6 MBytes  499909 Kbits/sec    0    165 KBytes
+...
+```
+
+### Format Characteristics
+- **Header**: `[ ID][Role] Interval           Transfer     Bitrate         Retr  Cwnd`
+- **HAS** `[Role]` column with values like `[TX-C]`, `[RX-C]`, `[TX-S]`, `[RX-S]`
+- **Column Positions** (shifted by 1 compared to unidirectional):
+  - `columns[0]`: ID (e.g., `[  5]`)
+  - `columns[1]`: Role (e.g., `[TX-C]`)
+  - `columns[2]`: (empty/whitespace)
+  - `columns[3]`: Interval (e.g., `0.00-1.00`)
+  - `columns[4]`: "sec"
+  - `columns[5]`: Transfer amount
+  - `columns[6]`: Transfer unit
+  - `columns[7]`: Bitrate value
+  - `columns[8]`: Bitrate unit
+  - `columns[9]`: Retry count - TX only
+  - `columns[10]`: Cwnd value - TX only
+
+### Role Markers
+- **TX-C**: Client transmitting (client → server)
+- **RX-C**: Client receiving (server → client)
+- **TX-S**: Server transmitting (server → client, same flow as RX-C)
+- **RX-S**: Server receiving (client → server, same flow as TX-C)
+
+### Data Line Detection
+Look for pattern: `\[\s*\d+\]\[([A-Z]{2}-[CS])\]` in the line
+- If found → bidirectional mode
+- Extract role from capture group
+
+### Processing Requirements
+- Detect bidirectional mode by finding `[TX-C]`, `[RX-C]`, `[TX-S]`, or `[RX-S]` in data lines
+- Parse interval and bitrate using dynamic column search (can't use hardcoded indices)
+- Aggregate samples with matching timestamps:
+  - TX-C and TX-S both contribute to `tx-Gbps`
+  - RX-C and RX-S both contribute to `rx-Gbps`
+  - Accumulate values for same timestamp across different flows
+- Log aggregated samples at end of processing
+
+### Expected Output
+- For 10-second test with --omit=3:
+  - 7 aggregated time intervals
+  - Each interval has both `tx-Gbps` and `rx-Gbps` metrics
+  - Values are sums of client and server contributions for that interval
+- Metric types: `tx-Gbps` (aggregated), `rx-Gbps` (aggregated), `tx-retry/sec`
+
+---
+
+## 3. UDP Unidirectional
+
+### Format Differences from TCP
+- **TX lines**: `[ ID] Interval Transfer Bitrate Total Datagrams`
+- **RX lines**: `[ ID] Interval Transfer Bitrate Jitter Lost/Total Datagrams`
+- Loss pattern: `8/38128` (lost/total) followed by percentage `(0.021%)`
+
+### Processing Requirements
+- Detect RX by presence of `Lost/Total` pattern
+- Parse lost/total values
+- Apply omit filter to lost values (set to 0 if within omit period)
+- Log `rx-lost/sec` and `rx-pps` metrics for RX lines
+
+---
+
+## Summary of Key Differences
+
+| Feature | Unidirectional | Bidirectional |
+|---------|---------------|---------------|
+| Role column | NO | YES |
+| Column indices | Fixed (col 2, 6, 8) | Shifted (+1) |
+| Detection | No role markers in data | `[TX-C]`, `[RX-C]`, etc. in data |
+| Processing | Log each line immediately | Accumulate then aggregate |
+| Sample count | ~10 individual samples | ~10 aggregated intervals |
+| Metric types | tx-Gbps OR rx-Gbps per line | tx-Gbps AND rx-Gbps per interval |

--- a/README.md
+++ b/README.md
@@ -5,12 +5,160 @@ Scripts and configuration to run the [iperf3](https://github.com/esnet/iperf) ne
 
 See the [crucible-examples iperf documentation](https://github.com/perftool-incubator/crucible-examples/blob/main/iperf/README.md) for usage examples.
 
+## Features
+
+- **Bidirectional traffic** - Simultaneous TX/RX measurement with `--bidir` flag
+- **Multi-process per pod** - IRQ load sharing across multiple iperf engines (rickshaw creates engines, `num-peers` coordinates port allocation)
+- **IRQ/CPU pinning** - Pin iperf engine and NIC interrupts to specific CPUs for consistent performance
+- **Hunter mode** - Automatically find optimal bitrate with `--bitrate-range`
+- **Protocol support** - TCP and UDP with automatic detection in post-processing
+- **Comprehensive metrics** - tx-Gbps, rx-Gbps, tx-retry/sec, rx-lost/sec, rx-pps
+
+## Configuration
+
+### Bidirectional Mode
+
+Enable simultaneous TX and RX traffic measurement by passing `--bidir` to iperf3:
+
+```json
+{
+  "benchmarks": [
+    {
+      "name": "iperf",
+      "ids": [1],
+      "mv-params": {
+        "common-params": [
+          {
+            "arg": "passthru",
+            "vals": ["--bidir"]
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+In bidirectional mode:
+- Both client and server simultaneously transmit and receive
+- Post-processor aggregates TX and RX flows separately
+- Metrics generated: `tx-Gbps` and `rx-Gbps` from both endpoints
+- Role markers (`[TX-C]`, `[RX-C]`, `[TX-S]`, `[RX-S]`) identify each flow
+
+### Multi-Process with IRQ Load Sharing (SR-IOV)
+
+**Note**: This feature applies to SR-IOV mode only. In OVN-Kubernetes CNI, the pod interface `eth0` is a veth endpoint with no real IRQs to distribute.
+
+Distribute network interrupt load across multiple iperf processes by combining rickshaw's multi-engine configuration with the `num-peers` parameter.
+
+**Step 1: Configure multiple engines per pod (rickshaw endpoints configuration):**
+
+```json
+{
+  "endpoints": [
+    {
+      "type": "remotehosts",
+      "remotehost": "client-host",
+      "engines": {
+        "client": "1-4"
+      },
+      "pods": [
+        {
+          "name": "client-pod",
+          "engines": [
+            {
+              "role": "client",
+              "ids": "1+2+3+4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "remotehosts",
+      "remotehost": "server-host",
+      "engines": {
+        "server": "1-4"
+      },
+      "pods": [
+        {
+          "name": "server-pod",
+          "engines": [
+            {
+              "role": "server",
+              "ids": "1+2+3+4"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Step 2: Set `num-peers` to inform each engine about its siblings:**
+
+```json
+{
+  "benchmarks": [
+    {
+      "name": "iperf",
+      "ids": [1],
+      "mv-params": {
+        "common-params": [
+          {
+            "arg": "num-peers",
+            "vals": ["4"]
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+How this works:
+- Rickshaw creates 4 iperf engine processes per pod
+- `num-peers: 4` tells each engine "you have 3 siblings sharing the NIC"
+- NIC IRQs are pinned to engine CPUs in round-robin fashion
+- Example: With 8 IRQs (8 queues) and 4 engines, each engine CPU handles 2 IRQs
+- Improves scalability on high-speed networks by avoiding single-core bottlenecks
+
+### IRQ/CPU Pinning
+
+Pin iperf processes and NIC interrupts to specific CPUs for consistent performance:
+
+```json
+{
+  "benchmarks": [
+    {
+      "name": "iperf",
+      "ids": [1],
+      "mv-params": {
+        "common-params": [
+          {
+            "arg": "cpu-pin",
+            "vals": ["4,5,6,7"]
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+CPU pinning:
+- Pins iperf engine processes to specified CPUs
+- Pins NIC IRQs to the same CPU set for NUMA locality
+- Reduces jitter and improves measurement consistency
+
 ## Key Files
 
 | File | Purpose |
 |------|---------|
 | `rickshaw.json` | Rickshaw integration: defines client/server scripts and parameter transformations |
-| `iperf-client` | Client-side benchmark execution |
-| `iperf-server-start` / `iperf-server-stop` | Server lifecycle scripts |
-| `iperf-post-process` | Post-processing: parses iperf output into crucible metrics |
+| `iperf-client` | Client-side benchmark execution with multi-process and IRQ pinning support |
+| `iperf-server-start` / `iperf-server-stop` | Server lifecycle scripts with IRQ pinning |
+| `iperf-post-process` | Post-processing: parses iperf output into crucible metrics (supports bidirectional mode) |
 | `workshop.json` | Engine image build requirements |
+| `unit-test/` | Test infrastructure for post-processor validation |

--- a/iperf-base
+++ b/iperf-base
@@ -35,3 +35,10 @@ function assign-pin-cpu {
     echo $1: $cpu_pin_cmd
 }
 
+# Source IRQ pinning functions
+if [ -f /usr/bin/iperf-pin ]; then
+    source /usr/bin/iperf-pin
+elif [ -f ./iperf-pin ]; then
+    source ./iperf-pin
+fi
+

--- a/iperf-client
+++ b/iperf-client
@@ -25,9 +25,10 @@ bend=0
 bitrate_range=
 max_loss_pct=0
 omit=0
+num_peers=0
 
 echo "opts before: $@"
-longopts="ipv:,ifname:,protocol:,length:,remotehost:,time:,bitrate:,cpu-pin:,passthru:,bitrate-range:,max-loss-pct:,omit:"
+longopts="ipv:,ifname:,protocol:,length:,remotehost:,time:,bitrate:,cpu-pin:,passthru:,bitrate-range:,max-loss-pct:,omit:,num-peers:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     exit_error "Unrecognized option specified"
@@ -112,6 +113,12 @@ while true; do
             echo "omit=$omit"
             shift
             ;;
+        --num-peers)     # number of siblings for IRQ pinning
+            shift;
+            num_peers=$1
+            echo "num-peers=$num_peers"
+            shift
+            ;;
         --)
             shift;
             break
@@ -120,6 +127,18 @@ while true; do
             exit_error "Invalid option: $1"
     esac
 done
+
+# IRQ pinning if num_peers is specified
+if [ "$num_peers" -gt 0 ]; then
+    # Check if this is a physical/VF interface (not veth)
+    if [ -e "/sys/class/net/$ifname/device/msi_irqs" ]; then
+        echo "Calling run_iperf_worker with num_peers=$num_peers and ifname=$ifname"
+        export IFACE="$ifname"
+        run_iperf_worker "$num_peers"
+    else
+        echo "INFO: Skipping IRQ pinning for $ifname (not a physical/VF interface, likely veth in OVN-K)"
+    fi
+fi
 
 case "${cpu_pin}" in
     ""|"numa"|"cpu-numa")
@@ -231,7 +250,7 @@ case "${cpu_pin}" in
         ;;
 esac
 
-options="--format k -c $remotehost -p $control_port $protocol $length --get-server-output"
+options="--format k -c $remotehost -p $control_port $protocol $length"
 if [ "$omit" -ne 0 ]; then
     options+=" --omit $omit"
 fi
@@ -276,6 +295,31 @@ if [ "$bitrate_range" != "" ]; then
     generic-hunter --begin $bstart --end $bend  --max-loss-pct $max_loss_pct iperf-drop-hunter $unit
     exit
 fi
+
+timeout_sec=10
+interval=1
+elapsed=0
+start_time=$SECONDS
+
+until (echo >/dev/tcp/$remotehost/$control_port) &>/dev/null; do
+    elapsed=$((SECONDS - start_time))
+    if [ $elapsed -ge $timeout_sec ]; then
+        echo "ERROR: $remotehost:$control_port unreachable after ${timeout_sec}s"
+        exit 1
+    fi
+    echo "Waiting for $remotehost:$control_port... (${elapsed}s)"
+    sleep $interval
+done
+
+# Sleep remaining time so all parallel pods start together
+elapsed=$((SECONDS - start_time))
+remaining=$((timeout_sec - elapsed))
+if [ $remaining -gt 0 ]; then
+    echo "$remotehost:$control_port is ready, waiting ${remaining}s for other pods..."
+    sleep $remaining
+fi
+
+echo "Starting iperf3..."
 
 echo BEGIN-TS-0 $(date +%s.%N) > iperf-client-result.txt
 ${cmd} 2>&1 >> iperf-client-result.txt

--- a/iperf-pin
+++ b/iperf-pin
@@ -1,0 +1,209 @@
+#!/bin/bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
+#
+# iperf-pin — Autonomous IRQ pinning for iperf siblings
+#
+# Purpose:
+#   Distributes NIC IRQ handling across multiple iperf sibling containers using
+#   a deterministic two-level round-robin algorithm. Each container independently
+#   calculates which IRQs it owns based on its sibling index.
+#
+# Algorithm:
+#   Level 1: Distribute IRQs across siblings — IRQ[i] → sibling[i % NUM_PEERS]
+#   Level 2: Pin owned IRQs to CPUs — owned_IRQ[j] → CPU[j % NUM_CPUS]
+#
+# Requirements:
+#   - cs_label environment variable with format "role-N" (e.g., "client-0", "server-1")
+#   - IFACE environment variable set to network interface name
+#   - Container must have privileged access to /proc/irq/*/smp_affinity
+#
+# Usage:
+#   run_iperf_worker <num_peers>
+#
+# Each container runs this identically. No master, no coordination required.
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+expand_cpuset() {
+    # Expand "0-3,5,7-9" → "0 1 2 3 5 7 8 9"
+    local raw="$1"
+    python3 -c "
+r=[]
+for p in '${raw}'.split(','):
+    parts = p.strip().split('-')
+    if len(parts) == 2:
+        r.extend(range(int(parts[0]), int(parts[1])+1))
+    else:
+        r.append(int(parts[0]))
+print(' '.join(map(str, r)))
+"
+}
+
+get_my_cpus() {
+    # Read container's assigned CPUs from cgroup
+    local raw
+
+    # Try container-specific cgroup path first (cgroup v2)
+    local cgroup_path=$(cat /proc/self/cgroup 2>/dev/null | cut -d: -f3)
+    if [[ -n "$cgroup_path" ]]; then
+        raw=$(cat /sys/fs/cgroup${cgroup_path}/cpuset.cpus.effective 2>/dev/null \
+           || cat /sys/fs/cgroup${cgroup_path}/cpuset.cpus 2>/dev/null \
+           || echo "")
+    fi
+
+    # Fall back to root cgroup paths
+    if [[ -z "$raw" ]]; then
+        raw=$(cat /sys/fs/cgroup/cpuset.cpus.effective 2>/dev/null \
+           || cat /sys/fs/cgroup/cpuset.cpus 2>/dev/null \
+           || cat /sys/fs/cgroup/cpuset/cpuset.cpus 2>/dev/null \
+           || echo "")
+    fi
+
+    if [[ -z "$raw" ]]; then
+        echo "FATAL: cannot read cpuset" >&2
+        return 1
+    fi
+
+    # Expand and return all assigned CPUs
+    local cpus
+    cpus=$(expand_cpuset "$raw")
+
+    if [[ -z "$cpus" ]]; then
+        echo "FATAL: no CPUs in cpuset '$raw'" >&2
+        return 1
+    fi
+
+    echo "${cpus}"
+}
+
+get_nic_irqs() {
+    # Return sorted TxRx IRQs for iface via sysfs + /proc/interrupts filter
+    local iface="$1"
+    local irq_dir="/sys/class/net/${iface}/device/msi_irqs"
+
+    if [[ ! -d "$irq_dir" ]]; then
+        echo "FATAL: $irq_dir not found — is $iface a PCI device?" >&2
+        return 1
+    fi
+
+    for irq in $(ls "$irq_dir" | sort -n); do
+        grep -P "^\s*${irq}:" /proc/interrupts | grep -qiE 'TxRx|mlx5_comp' && echo "$irq"
+    done
+}
+
+validate_irqs() {
+    local n_irqs=$1 n_peers=$2 iface=$3
+    if [[ $n_irqs -lt $n_peers ]]; then
+        echo "FATAL: $iface has $n_irqs TxRx IRQs but NUM_PEERS=$n_peers" >&2
+        echo "       Reduce numVfs in SriovNetworkNodePolicy so this VF gets >= $n_peers queues" >&2
+        return 1
+    fi
+    return 0
+}
+
+# ── Core assignment function ──────────────────────────────────────────────────
+#
+# assign_and_pin IRQS MY_INDEX NUM_PEERS MY_CPUS [DRY_RUN]
+#
+# IRQS      — space-separated sorted IRQ numbers
+# MY_INDEX  — this sibling's index (0-based)
+# NUM_PEERS — total sibling count
+# MY_CPUS   — space-separated CPU list for this sibling
+# DRY_RUN   — if "1", print assignments but do not write smp_affinity
+#
+# Level 1 round-robin: IRQ[i] belongs to sibling[i % NUM_PEERS]
+# Level 2 round-robin: owned IRQ[j] pins to MY_CPUS[j % len(MY_CPUS)]
+#
+assign_and_pin() {
+    local -a irqs=($1)
+    local my_index=$2
+    local num_peers=$3
+    local -a my_cpus=($4)
+    local dry_run=${5:-0}
+
+    local n_irqs=${#irqs[@]}
+    local n_cpus=${#my_cpus[@]}
+    local my_irq_count=0
+    local tag="[sibling-${my_index}]"
+
+    echo "$tag IRQs=$n_irqs peers=$num_peers my_cpus=(${my_cpus[*]})"
+
+    for (( i=0; i<n_irqs; i++ )); do
+        if (( i % num_peers == my_index )); then
+            local irq="${irqs[$i]}"
+            local cpu="${my_cpus[$((my_irq_count % n_cpus))]}"
+            local mask
+
+            # Calculate bitmask for CPU affinity
+            # For CPUs >= 32, we need comma-separated format: high,low
+            if (( cpu >= 32 )); then
+                local high_bits=$(( cpu - 32 ))
+                mask=$(printf '%08x,%08x' $((1 << high_bits)) 0)
+            else
+                mask=$(printf '%x' $((1 << cpu)))
+            fi
+
+            if [[ "$dry_run" == "1" ]]; then
+                echo "$tag  [DRY] IRQ $irq (queue $i) → CPU $cpu  mask $mask"
+            else
+                if echo "$mask" > /proc/irq/${irq}/smp_affinity 2>/dev/null; then
+                    echo "$tag  PIN  IRQ $irq (queue $i) → CPU $cpu  mask $mask  [ok]"
+                else
+                    echo "$tag  WARN IRQ $irq (queue $i) → CPU $cpu  mask $mask  [failed: $(cat /proc/irq/${irq}/smp_affinity 2>/dev/null)]" >&2
+                fi
+            fi
+            (( my_irq_count++ ))
+        fi
+    done
+
+    echo "$tag Owns $my_irq_count / $n_irqs IRQs"
+}
+
+# ── Entrypoint ────────────────────────────────────────────────────────────────
+run_iperf_worker() {
+    local num_peers="$1"
+    local iface="${IFACE:?need IFACE}"
+    local dry_run="${DRY_RUN:-0}"
+
+    # Validate num_peers argument
+    if [[ -z "$num_peers" ]] || ! [[ "$num_peers" =~ ^[0-9]+$ ]]; then
+        echo "FATAL: run_iperf_worker requires NUM_PEERS as first argument (got: '$num_peers')" >&2
+        exit 1
+    fi
+
+    # Auto-detect index from cs_label (rickshaw standard: "client-1", "server-2", etc.)
+    local container_name="${cs_label:-${CONTAINER_NAME}}"
+    if [[ -z "$container_name" ]]; then
+        echo "FATAL: need cs_label or CONTAINER_NAME environment variable" >&2
+        exit 1
+    fi
+
+    local my_index="${container_name##*-}"
+    if ! [[ "$my_index" =~ ^[0-9]+$ ]]; then
+        echo "FATAL: cannot parse index from cs_label/CONTAINER_NAME='$container_name'" >&2
+        exit 1
+    fi
+
+    # Convert from 1-based (rickshaw convention) to 0-based (for modulo arithmetic)
+    # rickshaw names containers: client-1, client-2, server-1, server-2, etc.
+    # We need 0, 1 for num_peers=2 modulo operations
+    my_index=$((my_index - 1))
+
+    # Collect own CPUs
+    local my_cpus
+    my_cpus=$(get_my_cpus) || exit 1
+
+    # Collect IRQs
+    local -a irqs
+    mapfile -t irqs < <(get_nic_irqs "$iface") || exit 1
+
+    # Validate
+    validate_irqs "${#irqs[@]}" "$num_peers" "$iface" || exit 1
+
+    # Assign and pin
+    assign_and_pin "${irqs[*]}" "$my_index" "$num_peers" "$my_cpus" "$dry_run"
+
+    echo "[$container_name] IRQ pinning complete"
+}
+

--- a/iperf-post-process.py
+++ b/iperf-post-process.py
@@ -40,17 +40,82 @@ def get_rate_divisor(rateunit):
         sys.exit(1)
 
 
+def extract_role(line):
+    """Extract role marker from bidirectional output line.
+
+    Returns role string like 'TX-C', 'RX-C', 'TX-S', 'RX-S', or None if not bidir.
+    """
+    # Pattern: [ ID][Role] e.g., "[  5][TX-C]"
+    match = re.search(r'\[\s*\d+\]\[([A-Z]{2}-[CS])\]', line)
+    if match:
+        return match.group(1)
+    return None
+
+
 def dup_one_run(fh, first_line, outfile):
-    with open(outfile, "w") as ofh:
+    # Write to temp file first, then atomic rename to prevent race condition
+    # where server might read partially-written file
+    temp_file = outfile + ".tmp"
+    with open(temp_file, "w") as ofh:
         ofh.write(first_line)
         for line in fh:
             ofh.write(line)
             if "END-TS" in line:
                 break
 
+    # Atomic rename - file appears complete or not at all
+    os.rename(temp_file, outfile)
 
-def pre_process_hunting_results(from_file, to_file):
+
+def pre_process_hunting_results(from_file, to_file, client_hunt_result=None):
+    """Extract the best run from hunting results.
+
+    For client: finds highest bitrate PASS and extracts that run.
+    For server: reads which run the client selected, then extracts that test number.
+    """
     debug_print("process_hunting_results: enter\n")
+
+    # Server mode: extract run number from client's hunt-temp-result.txt
+    if client_hunt_result is not None:
+        # Server mode - MUST have client hunt result file
+        # Wait up to 30 seconds for the file to appear (client might still be post-processing)
+        import time
+        max_wait = 30
+        wait_interval = 0.5
+        waited = 0
+        while not os.path.exists(client_hunt_result) and waited < max_wait:
+            if waited == 0:
+                print(f"Waiting for client hunt result file: {client_hunt_result}")
+            time.sleep(wait_interval)
+            waited += wait_interval
+
+        if not os.path.exists(client_hunt_result):
+            print(f"ERROR: Server hunting mode requires {client_hunt_result} to exist")
+            print(f"Waited {max_wait} seconds but file was not created")
+            print("Client post-processing must complete first to create this file")
+            sys.exit(1)
+        elif waited > 0:
+            print(f"Client hunt result file appeared after {waited:.1f} seconds")
+
+        print(f"Server hunting mode: reading client's selected run from {client_hunt_result}")
+        try:
+            with open(client_hunt_result, 'r') as fh:
+                first_line = fh.readline()
+                # Client hunt-temp has "BEGIN-TS-N" where N is the run number
+                match = re.search(r'BEGIN-TS-(\d+)', first_line)
+                if match:
+                    selected_run = int(match.group(1))
+                    print(f"Client selected run {selected_run}, extracting test #{selected_run} from server results")
+                    extract_server_test(from_file, to_file, selected_run)
+                    return
+                else:
+                    print(f"ERROR: Could not find BEGIN-TS-N pattern in {client_hunt_result}")
+                    sys.exit(1)
+        except Exception as e:
+            print(f"ERROR: Failed to read client hunt result: {e}")
+            sys.exit(1)
+
+    # Client mode: find highest bitrate PASS
     highest_bitrate = 0
     highest_run_number = 0
     cur_run_number = 0
@@ -66,12 +131,31 @@ def pre_process_hunting_results(from_file, to_file):
         debug_print(f"Proc line: {line}")
         if "PASS" in line:
             columns = line.split()
-            bitrate = float(columns[7])
+            # Find bitrate by searching for "bits/sec" pattern (same as interval parsing)
+            bitrate = None
+            for i in range(len(columns) - 1):
+                if 'bits/sec' in columns[i + 1]:
+                    try:
+                        bitrate = float(columns[i])
+                        break
+                    except (ValueError, IndexError):
+                        continue
+
+            if bitrate is None:
+                # Skip PASS lines where we couldn't find bitrate
+                debug_print(f"Could not extract bitrate from PASS line: {line}")
+                continue
+
             if bitrate > highest_bitrate:
                 highest_bitrate = bitrate
                 highest_run_number = cur_run_number
     fh.close()
     print(f"Highest run num = {highest_run_number}")
+
+    if highest_run_number == 0:
+        print("WARNING: No PASS found in hunting results - using last run")
+        # Use the last run instead
+        highest_run_number = cur_run_number
 
     fh, _ = open_read_text_file(from_file)
     cur_run_number = 0
@@ -84,13 +168,83 @@ def pre_process_hunting_results(from_file, to_file):
     fh.close()
 
 
-def process_proto(data_file, protocol, times, names, omit, metrics):
+def extract_server_test(from_file, to_file, test_number):
+    """Extract a specific test number from server result file.
+
+    Server output has markers like 'Server listening on 30002 (test #N)'
+    We also need to read the timestamps from the client's hunt-temp-result.txt
+    """
+    try:
+        fh, _ = open_read_text_file(from_file)
+    except FileNotFoundError:
+        print(f"ERROR: Could not open {from_file}")
+        return
+
+    # Read timestamps from client hunt-temp-result.txt
+    client_hunt = "../../client/1/hunt-temp-result.txt"
+    begin_ts = None
+    end_ts = None
+    if os.path.exists(client_hunt):
+        with open(client_hunt, 'r') as cfh:
+            for line in cfh:
+                if f"BEGIN-TS-{test_number}" in line:
+                    begin_ts = line.strip()
+                elif f"END-TS-{test_number}" in line:
+                    end_ts = line.strip()
+                    break
+
+    # Find the test marker
+    target_marker = f"(test #{test_number})"
+    next_test_marker = f"(test #{test_number + 1})"
+    in_target_test = False
+
+    # Write to temp file first, then atomic rename to prevent race condition
+    temp_file = to_file + ".tmp"
+    with open(temp_file, "w") as ofh:
+        # Write BEGIN timestamp if found
+        if begin_ts:
+            ofh.write(begin_ts + "\n")
+
+        for line in fh:
+            if target_marker in line:
+                in_target_test = True
+                debug_print(f"Found start of {target_marker}\n")
+                continue  # Skip the "Server listening" line
+
+            if in_target_test:
+                if next_test_marker in line or "END-TS" in line:
+                    # Reached next test or end marker
+                    debug_print(f"Reached end of test {test_number}\n")
+                    break
+                ofh.write(line)
+
+        # Write END timestamp if found
+        if end_ts:
+            ofh.write(end_ts + "\n")
+
+    fh.close()
+
+    # Atomic rename - file appears complete or not at all
+    os.rename(temp_file, to_file)
+    print(f"Extracted test #{test_number} from server results")
+
+
+def process_proto(data_file, times, names, omit, metrics):
     print("process_proto: enter")
     rateunit = "none"
     bitrate_div = 1
     sample_count = 0
     primary_metric = None
     ts = times["begin"]
+    bidir_mode = False
+    # For bidirectional: accumulate samples by timestamp
+    # Key: (begin_ts, end_ts), Value: {'tx-Gbps': value, 'rx-Gbps': value}
+    throughput_samples = {}
+
+    # Track whether we've seen header (for protocol detection)
+    has_retr_column = False  # TCP sender has "Retr" column
+    has_lost_total_column = False  # UDP receiver has "Lost/Total" column
+    has_datagrams_column = False  # UDP has "Datagrams" column
 
     try:
         fh, _ = open_read_text_file(data_file)
@@ -101,6 +255,28 @@ def process_proto(data_file, protocol, times, names, omit, metrics):
 
     for line in fh:
         line = line.rstrip("\n")
+
+        # Detect protocol from header line (but don't use for column positions!)
+        if "[ ID]" in line and "Interval" in line:
+            print(f"Header line: {line}")
+            if "Retr" in line:
+                has_retr_column = True
+                print("Detected TCP sender mode (header has Retr column)")
+            if "Lost/Total" in line:
+                has_lost_total_column = True
+                print("Detected UDP receiver mode (header has Lost/Total column)")
+            if "Datagrams" in line:
+                has_datagrams_column = True
+                print("Detected UDP mode (header has Datagrams column)")
+            if not has_retr_column and not has_lost_total_column and not has_datagrams_column:
+                print("Detected TCP receiver mode (header has no special columns)")
+            continue
+
+        # Stop processing if we hit embedded server output (from --get-server-output)
+        if line == "Server output:":
+            print("Detected embedded server output - stopping client processing")
+            print("(Server data will be processed from separate server-result.txt file)")
+            break
 
         if "sender" in line or "receiver" in line:
             debug_print(f"Skip line: {line}\n")
@@ -114,117 +290,225 @@ def process_proto(data_file, protocol, times, names, omit, metrics):
         if "omitted" in line:
             continue
 
-        if protocol == "udp":
-            if " sec " in line:
-                debug_print(f"Proc line: {line}\n")
-                columns = line.split()
+        # Parse data lines - use header detection to determine protocol-specific parsing
+        # UDP is identified by "Lost/Total" (receiver) or "Datagrams" (sender or receiver)
+        # TCP is identified by "Retr" (sender) or no special columns (receiver)
+        is_udp_line = has_lost_total_column or has_datagrams_column
 
-                tuble = columns[2].split("-")
-                start = float(tuble[0])
-                end = float(tuble[1])
-                sec_delta = end - start
+        if is_udp_line and " sec " in line:
+            debug_print(f"Proc line: {line}\n")
+            columns = line.split()
 
-                if sec_delta == 0:
-                    continue
+            # Find interval using X.XX-Y.YY pattern
+            interval_val = None
+            for col in columns:
+                if "-" in col and "." in col:
+                    try:
+                        parts = col.split("-")
+                        if len(parts) == 2:
+                            start = float(parts[0])
+                            end = float(parts[1])
+                            sec_delta = end - start
+                            if sec_delta > 0:
+                                interval_val = sec_delta * SEC_TO_MSEC
+                                break
+                    except ValueError:
+                        continue
 
-                interval = sec_delta * SEC_TO_MSEC
-                debug_print(f"interval={interval}\n")
+            if interval_val is None or interval_val == 0:
+                continue
 
-                bitrate = float(columns[6])
-                debug_print(f"bitrate {bitrate}\n")
+            debug_print(f"interval={interval_val}\n")
 
-                if rateunit == "none":
-                    rateunit = columns[7]
-                    bitrate_div = get_rate_divisor(rateunit)
+            # Find bitrate value (number before column containing 'bits/sec')
+            bitrate = None
+            bitrate_unit_idx = None
+            for i in range(len(columns) - 1):
+                if 'bits/sec' in columns[i + 1]:
+                    try:
+                        bitrate = float(columns[i])
+                        bitrate_unit_idx = i + 1
+                        break
+                    except ValueError:
+                        continue
 
-                ts_end = ts + interval - 1
-                num_fields = len(columns)
+            if bitrate is None:
+                continue
 
-                if num_fields > 10:
-                    lost_total = columns[10]
-                    tuble = lost_total.split("/")
-                    lost = int(tuble[0])
-                    total = int(tuble[1])
-                    debug_print(f"Lost:{lost} Total:{total}\n")
+            debug_print(f"bitrate {bitrate}\n")
 
-                    if omit != 0 and end <= omit:
-                        debug_print(f"fudge lost value due to on-demand omit, line: {line}\n")
-                        lost = 0
+            if rateunit == "none":
+                rateunit = columns[bitrate_unit_idx]
+                bitrate_div = get_rate_divisor(rateunit)
 
-                    desc = {"source": "iperf", "class": "throughput", "type": "rx-lost/sec"}
-                    s = {"begin": int(ts), "end": int(ts_end), "value": lost}
-                    debug_print(f"log_sample: lost={lost}\n")
-                    metrics.log_sample("0", desc, names, s)
+            ts_end = ts + interval_val - 1
 
-                    desc = {"source": "iperf", "class": "throughput", "type": "rx-pps"}
-                    s = {"begin": int(ts), "end": int(ts_end), "value": total}
-                    metrics.log_sample("0", desc, names, s)
+            # Find Lost/Total column by searching for X/Y pattern (receiver side)
+            lost_total_idx = None
+            for i, col in enumerate(columns):
+                if "/" in col and "bits/sec" not in col:
+                    lost_total_idx = i
+                    break
 
-                    if primary_metric is None:
-                        primary_metric = "rx-Gbps"
-                        debug_print(f"primary_metric {primary_metric}\n")
+            print(f"UDP: Found lost_total_idx={lost_total_idx} in columns: {columns}")
+            if lost_total_idx is not None:
+                lost_total = columns[lost_total_idx]
+                # Extract the "X/Y" part from "X/Y(pct%)" format
+                lost_total_clean = lost_total.split("(")[0] if "(" in lost_total else lost_total
+                parts = lost_total_clean.split("/")
+                if len(parts) == 2:
+                    try:
+                        lost = int(parts[0])
+                        total = int(parts[1])
 
-                    debug_print(f"log_sample: primary_metric={primary_metric}\n")
-                    desc = {"source": "iperf", "class": "throughput", "type": primary_metric}
+                        print(f"UDP: Logging rx-lost/sec={lost}, rx-pps={total}")
+
+                        desc = {"source": "iperf", "class": "throughput", "type": "rx-lost/sec"}
+                        s = {"begin": int(ts), "end": int(ts_end), "value": lost}
+                        metrics.log_sample("0", desc, names, s)
+
+                        desc = {"source": "iperf", "class": "throughput", "type": "rx-pps"}
+                        s = {"begin": int(ts), "end": int(ts_end), "value": total}
+                        metrics.log_sample("0", desc, names, s)
+
+                        if primary_metric is None:
+                            primary_metric = "rx-Gbps"
+
+                        desc = {"source": "iperf", "class": "throughput", "type": primary_metric}
+                    except (ValueError, IndexError) as e:
+                        print(f"UDP: Error parsing Lost/Total: {e}")
+                        # Fall through to log just throughput
+                        if primary_metric is None:
+                            primary_metric = "tx-Gbps"
+                        desc = {"source": "iperf", "class": "throughput", "type": primary_metric}
                 else:
+                    print(f"UDP: len(parts)={len(parts)}, not 2 - sender side")
                     desc = {"source": "iperf", "class": "throughput", "type": "tx-Gbps"}
-
-                s = {"begin": int(ts), "end": int(ts_end), "value": bitrate / bitrate_div}
-                debug_print(f"begin: int {ts}, end: int {ts_end}\n")
-                metrics.log_sample("0", desc, names, s)
-                sample_count += 1
-                ts = ts + interval
             else:
-                debug_print(f"Skip line: {line}\n")
+                print(f"UDP: No Lost/Total found - sender side")
+                desc = {"source": "iperf", "class": "throughput", "type": "tx-Gbps"}
 
-        else:
+            s = {"begin": int(ts), "end": int(ts_end), "value": bitrate / bitrate_div}
+            debug_print(f"begin: int {ts}, end: int {ts_end}\n")
+            metrics.log_sample("0", desc, names, s)
+            sample_count += 1
+            ts = ts + interval_val
+
+        elif not is_udp_line and re.search(r'sec\s', line):
             # TCP
-            if re.search(r'sec\s', line):
-                debug_print(f"Proc line: {line}\n")
-                columns = line.split()
+            debug_print(f"Proc line: {line}\n")
 
-                tuble = columns[2].split("-")
-                start = float(tuble[0])
-                end = float(tuble[1])
-                sec_delta = end - start
-                interval = sec_delta * SEC_TO_MSEC
-                debug_print(f"interval={interval}\n")
+            # Check for bidirectional role marker
+            role = extract_role(line)
+            if role and not bidir_mode:
+                bidir_mode = True
+                print("BIDIRECTIONAL MODE DETECTED from role markers in output")
+                print("TX and RX throughput will be aggregated separately")
+                print()
 
-                if sec_delta == 0:
-                    continue
+            columns = line.split()
 
-                bitrate = float(columns[6])
-                debug_print(f"bitrate {bitrate}\n")
+            # Find interval using X.XX-Y.YY pattern
+            interval_val = None
+            for col in columns:
+                if "-" in col and "." in col:
+                    try:
+                        parts = col.split("-")
+                        if len(parts) == 2:
+                            start = float(parts[0])
+                            end = float(parts[1])
+                            sec_delta = end - start
+                            if sec_delta > 0:
+                                interval_val = sec_delta * SEC_TO_MSEC
+                                break
+                    except ValueError:
+                        continue
 
-                if rateunit == "none":
-                    rateunit = columns[7]
-                    bitrate_div = get_rate_divisor(rateunit)
+            if interval_val is None or interval_val == 0:
+                continue
 
-                num_fields = len(columns)
-                debug_print(f"num_fields: {num_fields}\n")
-                ts_end = ts + interval - 1
+            debug_print(f"interval={interval_val}\n")
 
-                if num_fields > 8:
-                    retry = int(columns[8])
-                    debug_print(f"Retry: {retry}\n")
+            # Find bitrate (number before column containing 'bits/sec')
+            bitrate = None
+            bitrate_unit_idx = None
+            for i in range(len(columns) - 1):
+                if 'bits/sec' in columns[i + 1]:
+                    try:
+                        bitrate = float(columns[i])
+                        bitrate_unit_idx = i + 1
+                        break
+                    except ValueError:
+                        continue
 
-                    desc = {"source": "iperf", "class": "count", "type": "tx-retry/sec"}
-                    s = {"begin": int(ts), "end": int(ts_end), "value": retry}
-                    metrics.log_sample("0", desc, names, s)
+            if bitrate is None:
+                continue
 
-                    desc = {"source": "iperf", "class": "throughput", "type": "tx-Gbps"}
+            debug_print(f"bitrate {bitrate}\n")
+
+            if rateunit == "none":
+                rateunit = columns[bitrate_unit_idx]
+                bitrate_div = get_rate_divisor(rateunit)
+
+            ts_end = ts + interval_val - 1
+
+            # Find retry value: search for integer AFTER bits/sec unit and BEFORE last 2 columns
+            # Pattern: ... Kbits/sec <retry> <cwnd_value> <cwnd_unit>
+            # The retry is the first integer after bits/sec
+            # If header has Retr column, this is TX side
+            is_tx = has_retr_column
+            if has_retr_column and bitrate_unit_idx is not None:
+                # Look for integer after bitrate_unit_idx
+                for i in range(bitrate_unit_idx + 1, len(columns) - 1):
+                    try:
+                        retry = int(columns[i])
+                        debug_print(f"Retry: {retry} at position {i}\n")
+
+                        desc = {"source": "iperf", "class": "count", "type": "tx-retry/sec"}
+                        s = {"begin": int(ts), "end": int(ts_end), "value": retry}
+                        metrics.log_sample("0", desc, names, s)
+                        break  # Found retry, stop searching
+                    except (ValueError, IndexError):
+                        # Not an integer, keep looking
+                        continue
+
+            # Determine metric type
+            if bidir_mode and role:
+                # In bidir mode, TX-* roles map to tx-Gbps, RX-* to rx-Gbps
+                metric_type = 'tx-Gbps' if role.startswith('TX') else 'rx-Gbps'
+                # Set primary_metric on first RX sample
+                if primary_metric is None and metric_type == 'rx-Gbps':
+                    primary_metric = 'rx-Gbps'
+                    debug_print(f"primary_metric {primary_metric}\n")
+            else:
+                # Unidirectional mode
+                if is_tx:
+                    metric_type = "tx-Gbps"
                 else:
                     if primary_metric is None:
                         primary_metric = "rx-Gbps"
                         debug_print(f"primary_metric {primary_metric}\n")
-                    desc = {"source": "iperf", "class": "throughput", "type": primary_metric}
+                    metric_type = primary_metric
 
-                s = {"begin": int(ts), "end": int(ts_end), "value": bitrate / bitrate_div}
-                metrics.log_sample("0", desc, names, s)
-                sample_count += 1
-                ts = ts + interval
+            throughput_value = bitrate / bitrate_div
+
+            if bidir_mode:
+                # Accumulate for later aggregation
+                key = (int(ts), int(ts_end))
+                if key not in throughput_samples:
+                    throughput_samples[key] = {}
+                if metric_type not in throughput_samples[key]:
+                    throughput_samples[key][metric_type] = 0
+                throughput_samples[key][metric_type] += throughput_value
+                debug_print(f"Accum {metric_type} at {key}: {throughput_samples[key][metric_type]}\n")
             else:
-                debug_print(f"Skip line: {line}\n")
+                # Log immediately in unidirectional mode
+                desc = {"source": "iperf", "class": "throughput", "type": metric_type}
+                s = {"begin": int(ts), "end": int(ts_end), "value": throughput_value}
+                metrics.log_sample("0", desc, names, s)
+
+            sample_count += 1
+            ts = ts + interval_val
 
     if sample_count == 0:
         primary_metric = "rx-Gbps"
@@ -233,7 +517,22 @@ def process_proto(data_file, protocol, times, names, omit, metrics):
         metrics.log_sample("0", desc, names, s)
 
     fh.close()
+
+    # Log accumulated bidirectional samples
+    if bidir_mode and throughput_samples:
+        print(f"Logging {len(throughput_samples)} accumulated bidirectional samples")
+        for (begin_ts, end_ts), metrics_dict in sorted(throughput_samples.items()):
+            for metric_type, value in metrics_dict.items():
+                desc = {"source": "iperf", "class": "throughput", "type": metric_type}
+                s = {"begin": begin_ts, "end": end_ts, "value": value}
+                metrics.log_sample("0", desc, names, s)
+                debug_print(f"Logged {metric_type}: {value} Gbps for period {begin_ts}-{end_ts}\n")
+
     metric_data_name = metrics.finish_samples(dont_delete=True)
+
+    # Ensure primary_metric is set (default to rx-Gbps if not set)
+    if primary_metric is None:
+        primary_metric = "rx-Gbps"
 
     sample_data = {
         "rickshaw-bench-metric": {"schema": {"version": "2021.04.12"}},
@@ -259,7 +558,7 @@ def main():
     parser.add_argument("--remotehost", default=None)
     parser.add_argument("--length", default=None)
     parser.add_argument("--passthru", default=None)
-    parser.add_argument("--protocol", default=None)
+    parser.add_argument("--protocol", default=None)  # Accepted but ignored - protocol auto-detected from header
     parser.add_argument("--time", type=int, default=None)
     parser.add_argument("--bitrate", default=None)
     parser.add_argument("--max-loss-pct", default="0")
@@ -270,13 +569,35 @@ def main():
     parser.add_argument("--ipv", type=int, default=None)
     args, _ = parser.parse_known_args()
 
-    print(" ".join(sys.argv[1:]))
+    # Print header - rickshaw redirects to post-process-output.txt
+    print("=== iperf-post-process.py (unidirectional + bidirectional support) ===")
+    print(f"Arguments: {' '.join(sys.argv)}")
+    print("=" * 60)
+    print()
 
-    protocol = args.protocol
     hunting_mode = args.bitrate_range != "0"
     omit_val = args.omit
 
-    result_file = "iperf-client-result.txt"
+    # Detect if running on server vs client
+    is_server = False
+    if os.path.exists("iperf-client-result.txt"):
+        result_file = "iperf-client-result.txt"
+        timestamp_file = result_file  # Client uses its own timestamps
+    elif os.path.exists("iperf-server-result.txt"):
+        result_file = "iperf-server-result.txt"
+        is_server = True
+        # Server reads timestamps from client result file
+        timestamp_file = "../../client/1/iperf-client-result.txt"
+        if not os.path.exists(timestamp_file):
+            print(f"ERROR: Server needs client timestamps from {timestamp_file}")
+            print("Client result file not found")
+            sys.exit(1)
+        print(f"Server mode: using timestamps from {timestamp_file}")
+    else:
+        print("ERROR: Neither iperf-client-result.txt nor iperf-server-result.txt found")
+        print("Is the current directory for an iperf run?")
+        sys.exit(1)
+
     final_hunt_result = "hunt-temp-result.txt"
     names = {"cmd": "write"}
 
@@ -287,34 +608,48 @@ def main():
     metrics = CDMMetrics()
 
     if not hunting_mode:
+        # Extract timestamps from timestamp_file (client file for both client and server)
         begin_out = subprocess.run(
-            f"grep BEGIN-TS {result_file} | awk '{{print $2}}'",
+            f"grep 'BEGIN-TS' {timestamp_file} | head -1 | awk '{{print $2}}'",
             shell=True, capture_output=True, text=True
         ).stdout.strip()
         end_out = subprocess.run(
-            f"grep END-TS {result_file} | awk '{{print $2}}'",
+            f"grep 'END-TS' {timestamp_file} | head -1 | awk '{{print $2}}'",
             shell=True, capture_output=True, text=True
         ).stdout.strip()
         times = {
             "begin": float(begin_out) * SEC_TO_MSEC,
             "end": float(end_out) * SEC_TO_MSEC,
         }
-        process_proto(result_file, protocol, times, names, omit_val, metrics)
+        process_proto(result_file, times, names, omit_val, metrics)
     else:
-        pre_process_hunting_results(result_file, final_hunt_result)
+        # Hunting mode: process selected run from result_file
+        # For server, pass client hunt result so it can extract the same run number
+        if is_server:
+            client_hunt_result = "../../client/1/hunt-temp-result.txt"
+            pre_process_hunting_results(result_file, final_hunt_result, client_hunt_result)
+            timestamp_source = client_hunt_result if os.path.exists(client_hunt_result) else timestamp_file
+        else:
+            # Client mode - find best run from its own results
+            pre_process_hunting_results(result_file, final_hunt_result)
+            timestamp_source = final_hunt_result
+
         begin_out = subprocess.run(
-            f"grep BEGIN-TS {final_hunt_result} | awk '{{print $2}}'",
+            f"grep BEGIN-TS {timestamp_source} | awk '{{print $2}}'",
             shell=True, capture_output=True, text=True
         ).stdout.strip()
         end_out = subprocess.run(
-            f"grep END-TS {final_hunt_result} | awk '{{print $2}}'",
+            f"grep END-TS {timestamp_source} | awk '{{print $2}}'",
             shell=True, capture_output=True, text=True
         ).stdout.strip()
         times = {
             "begin": float(begin_out) * SEC_TO_MSEC,
             "end": float(end_out) * SEC_TO_MSEC,
         }
-        process_proto(final_hunt_result, protocol, times, names, omit_val, metrics)
+        process_proto(final_hunt_result, times, names, omit_val, metrics)
+
+    # Print status to stdout for test infrastructure (on separate line)
+    print("POST-PROCESS-STATUS: success")
 
 
 if __name__ == "__main__":

--- a/iperf-server-start
+++ b/iperf-server-start
@@ -14,8 +14,12 @@ data_port=""
 ifname=""
 cpu_pin=""
 ipv="4"
+num_peers=0
+protocol=""
+bitrate_range=
+omit=0
 
-longopts="ipv:,ifname:,cpu-pin:,bitrate:,passthru:"
+longopts="ipv:,ifname:,cpu-pin:,bitrate:,passthru:,num-peers:,protocol:,bitrate-range:,omit:"
 opts=$(getopt -q -o "" --longoptions "$longopts" -n "getopt.sh" -- "$@");
 if [ $? -ne 0 ]; then
     exit_error  "Unrecognized option specified"
@@ -52,6 +56,34 @@ while true; do
             echo "pt_opts=$pt_opts"
             shift
             ;;
+        --num-peers)     # number of siblings for IRQ pinning
+            shift;
+            num_peers=$1
+            echo "num-peers=$num_peers"
+            shift
+            ;;
+        --protocol)
+            shift;
+            if [ "$1" == "udp" ]; then
+                protocol="--udp"
+            fi
+            echo "protocol=$protocol"
+            shift
+            ;;
+        --bitrate-range)     # iperf zero-drop hunt 
+            shift;
+            bitrate_range=$1
+            echo "bitrate-range=$bitrate_range"
+            bstart=$(echo $bitrate_range | awk -F'-' '{print $1}')
+            bend=$(echo $bitrate_range | awk -F'-' '{print $2}')
+            shift
+            ;;
+        --omit)     # skip first number of seconds
+            shift;
+            omit=$1
+            echo "omit=$omit"
+            shift
+            ;;
         --)
             shift;
             break
@@ -60,6 +92,18 @@ while true; do
             exit_error "Invalid option: $1"
     esac
 done
+
+# IRQ pinning if num_peers is specified
+if [ "$num_peers" -gt 0 ]; then
+    # Check if this is a physical/VF interface (not veth)
+    if [ -e "/sys/class/net/$ifname/device/msi_irqs" ]; then
+        echo "Calling run_iperf_worker with num_peers=$num_peers and ifname=$ifname"
+        export IFACE="$ifname"
+        run_iperf_worker "$num_peers"
+    else
+        echo "INFO: Skipping IRQ pinning for $ifname (not a physical/VF interface, likely veth in OVN-K)"
+    fi
+fi
 
 case "${cpu_pin}" in
     ""|"numa"|"cpu-numa")
@@ -216,7 +260,8 @@ if [ "$ipv" == "6" ]; then
 fi
 echo "going to run: $cmd"
 export MALLOC_CHECK_=2
-$cmd 2>&1 >iperf-server-result.txt &
+echo BEGIN-TS-0 $(date +%s.%N) > iperf-server-result.txt
+$cmd 2>&1 >> iperf-server-result.txt &
 pid=$!
 echo $pid >iperf-server.pid
 # Wait a little bit to see if the server errored out

--- a/iperf-server-stop
+++ b/iperf-server-stop
@@ -12,6 +12,8 @@ if [ -e iperf-server.pid ]; then
         echo "PID $pid still exists, trying kill -9"
         kill -9 $pid
     fi
+    # Add END-TS timestamp for post-processing
+    echo END-TS-0 $(date +%s.%N) >> iperf-server-result.txt
 else
     echo "iperf-server.pid not found"
     echo "PWD: `/bin/pwd`"

--- a/multiplex.json
+++ b/multiplex.json
@@ -19,7 +19,7 @@
         },
         "positive_integer": {
             "description": "a whole number greater than 0",
-            "args": [ "length", "time", "omit" ],
+            "args": [ "length", "time", "omit", "num-peers" ],
             "vals": "[1-9][0-9]*"
         },
         "bitrate": {

--- a/rickshaw.json
+++ b/rickshaw.json
@@ -15,6 +15,10 @@
                 "dest": "/usr/bin/"
             },
             {
+                "src": "%bench-dir%/iperf-pin",
+                "dest": "/usr/bin/"
+            },
+            {
                 "src": "%bench-dir%/iperf-get-runtime",
                 "dest": "/usr/bin/"
             },
@@ -34,6 +38,10 @@
         "files-from-controller": [
             {
                 "src": "%bench-dir%/iperf-base",
+                "dest": "/usr/bin/"
+            },
+            {
+                "src": "%bench-dir%/iperf-pin",
                 "dest": "/usr/bin/"
             },
             {

--- a/unit-test/.gitignore
+++ b/unit-test/.gitignore
@@ -1,0 +1,2 @@
+# Python virtual environment
+.venv/

--- a/unit-test/.skill
+++ b/unit-test/.skill
@@ -1,0 +1,162 @@
+# iperf Post-Processor Debug Skill
+
+You are debugging the iperf post-processor (`../iperf-post-process.py`). This unit-test directory contains test infrastructure to help validate fixes.
+
+## Current Working Directory
+You are in: `/opt/crucible/subprojects/benchmarks/iperf/unit-test/`
+
+## Available Test Infrastructure
+
+### Test Suite
+- **run-tests.py** - Runs all 8 test cases and reports pass/fail status
+- **test-data/** - Contains 8 test cases with real production data:
+  - `missing-timestamps/` - Failure detection test
+  - `tcp-unidirectional-client/` - TCP sender (tx-Gbps, tx-retry/sec)
+  - `tcp-unidirectional-server/` - TCP receiver (rx-Gbps)
+  - `tcp-bidirectional-client/` - TCP bidir client (tx-Gbps, rx-Gbps)
+  - `tcp-bidirectional-server/` - TCP bidir server (tx-Gbps, rx-Gbps)
+  - `udp-sender/` - UDP sender (tx-Gbps)
+  - `udp-receiver/` - UDP receiver (rx-Gbps, rx-lost/sec, rx-pps)
+  - `tcp-hunter-mode/` - Multiple bitrate runs with PASS/FAIL selection
+
+### Python Environment
+- **Local venv**: `.venv/` directory (Python 3.11)
+- **Bootstrap script**: `bootstrap.sh` creates/validates venv
+- Post-processor runs with: `.venv/bin/python3 ../iperf-post-process.py`
+
+## Debugging Workflow
+
+### Step 1: Identify the Problem
+Run the test suite to see which tests fail:
+```bash
+./run-tests.py
+```
+
+The output shows:
+- Which test cases fail
+- STDOUT from the post-processor (including error messages)
+- STDERR with Python tracebacks
+
+### Step 2: Reproduce the Issue Manually
+To debug a specific failing test (e.g., tcp-unidirectional-server):
+
+```bash
+# Copy test data to parent directory
+cp test-data/tcp-unidirectional-server/iperf-server-result.txt ..
+cp test-data/tcp-unidirectional-server/iperf-client-result.txt ..
+
+# Run post-processor directly with venv Python
+cd ..
+unit-test/.venv/bin/python3 iperf-post-process.py --protocol=tcp --ipv=4 --ifname=eth0
+
+# Return to unit-test directory
+cd unit-test
+```
+
+### Step 3: Examine Test Data
+Read the test case files to understand the input:
+```bash
+# View the iperf output that's failing
+cat test-data/tcp-unidirectional-server/iperf-server-result.txt
+
+# Check what metrics are expected
+cat test-data/tcp-unidirectional-server/expected-metrics.json
+```
+
+### Step 4: Fix the Post-Processor
+Edit `../iperf-post-process.py` to fix the issue.
+
+### Step 5: Validate the Fix
+Re-run the test suite to ensure:
+- The failing test now passes
+- No regressions (all 8 tests still pass)
+
+```bash
+./run-tests.py
+```
+
+### Step 6: Add Test Case if Needed
+If fixing a new bug, add a test case to prevent regression:
+
+```bash
+mkdir test-data/new-bug-case
+# Copy relevant iperf result files
+cp /path/to/iperf-client-result.txt test-data/new-bug-case/
+
+# Create expected-metrics.json
+cat > test-data/new-bug-case/expected-metrics.json << 'EOF'
+{
+  "protocol": "tcp",
+  "expected_metrics": ["rx-Gbps"],
+  "description": "Description of what this validates"
+}
+EOF
+```
+
+## Key Files to Understand
+
+### ../iperf-post-process.py
+Main post-processor script. Key functions:
+- `process_proto()` - Parses iperf output, detects protocol/mode, logs metrics
+- `extract_role()` - Identifies bidirectional role markers (TX-C, RX-S, etc.)
+- `pre_process_hunting_results()` - Handles hunter mode (selects best run)
+
+### Test Success Criteria
+Each test passes if the post-processor:
+1. Exits without Python exceptions
+2. Prints "POST-PROCESS-STATUS: success" to stdout
+
+For `should_fail` tests, success means:
+- Post-processor fails (no success marker in output)
+- This validates error detection works correctly
+
+## Common Issues and Solutions
+
+### Protocol Detection
+- TCP sender: Header has "Retr" column
+- TCP receiver: Header has no special columns
+- UDP receiver: Header has "Lost/Total" column
+- UDP: Header has "Datagrams" column
+
+### Bidirectional Mode
+- Detected by role markers: `[TX-C]`, `[RX-C]`, `[TX-S]`, `[RX-S]`
+- TX and RX throughput are aggregated separately by timestamp
+
+### Hunter Mode
+- Client: Selects highest bitrate PASS, extracts that run
+- Server: Reads client's selection, extracts matching test number
+
+## Important Notes
+
+- **Never commit failing tests** - All 8 tests must pass before committing
+- **Check for regressions** - Ensure fix doesn't break other test cases
+- **Test locally first** - Use this environment before running full crucible runs
+- **Add documentation** - Update IPERF-POST-PROCESS.md if changing behavior
+
+## Quick Reference Commands
+
+```bash
+# Run all tests
+./run-tests.py
+
+# Check venv exists
+ls .venv/bin/python3
+
+# Recreate venv if needed
+rm -rf .venv && ./bootstrap.sh
+
+# View post-processor
+cat ../iperf-post-process.py | less
+
+# Check git status
+cd .. && git status
+```
+
+## Success Criteria
+
+Before considering the issue fixed:
+1. ✅ All 8 tests pass (`./run-tests.py`)
+2. ✅ Manual reproduction confirms the fix
+3. ✅ No regressions introduced
+4. ✅ New test case added if fixing a new bug
+5. ✅ Documentation updated if behavior changed

--- a/unit-test/IPERF-POST-PROCESS.md
+++ b/unit-test/IPERF-POST-PROCESS.md
@@ -1,0 +1,882 @@
+# iperf Post-Processing Implementation
+
+## Overview
+
+The iperf post-processing pipeline parses iperf3 output and converts it into CDM (Common Data Model) metrics for indexing in OpenSearch. It supports both unidirectional and bidirectional traffic modes, TCP and UDP protocols, and hunter mode for automatic bitrate optimization.
+
+## Key Components
+
+### Main Scripts
+
+- **iperf-post-process.py** - Primary post-processor, handles all iperf output formats
+- **iperf-post-process-with-validation.py** - Wrapper that validates new code against upstream version
+- **upstream-iperf-post-process.py** - Original implementation for comparison/validation
+
+### File Locations
+
+Post-processing runs in these directories:
+```
+<run-dir>/run/iterations/iteration-N/sample-N/client/1/
+<run-dir>/run/iterations/iteration-N/sample-N/server/1/
+```
+
+## Architecture
+
+### Client vs Server Processing
+
+#### Client Side
+- Processes: `iperf-client-result.txt`
+- Contains: Client TX metrics, embedded server RX metrics (if using `--get-server-output`)
+- Generates: TX-focused metrics (tx-Gbps, tx-retry/sec for TCP)
+- Timestamps: BEGIN-TS and END-TS directly in client output
+
+#### Server Side
+- Processes: `iperf-server-result.txt`
+- Contains: Server RX metrics
+- Generates: RX-focused metrics (rx-Gbps, rx-pps, rx-lost/sec for UDP)
+- Timestamps: Read from client result file at `../../client/1/iperf-client-result.txt`
+
+**Critical Design Decision**: Server ALWAYS reads timestamps from the client result file because:
+1. Client and server clocks may not be synchronized
+2. Metrics must have aligned timestamps for proper correlation
+3. CDM requires consistent time references across client/server pairs
+
+### Metric Flow
+
+```
+iperf raw output
+    ↓
+parse headers to identify columns dynamically
+    ↓
+extract interval data (bitrate, Lost/Total, Retr, etc.)
+    ↓
+CDMMetrics.log_sample() for each metric type
+    ↓
+CDMMetrics.finish_samples(dont_delete=True)
+    ↓
+metric-data-0.json.xz (metric descriptors)
+metric-data-0.csv.xz (sample values)
+    ↓
+rickshaw-gen-docs.py (indexing)
+    ↓
+OpenSearch
+```
+
+## Header-Based Column Parsing
+
+### Problem
+iperf3 output format varies by protocol and mode:
+- UDP sender: `[ ID] Interval Transfer Bitrate Total Datagrams`
+- UDP receiver: `[ ID] Interval Transfer Bitrate Jitter Lost/Total Datagrams`
+- TCP sender: `[ ID] Interval Transfer Bitrate Retr`
+- TCP receiver: `[ ID] Interval Transfer Bitrate`
+- Bidirectional: `[ ID][Role] Interval Transfer Bitrate ...`
+
+Hardcoded column indices fail when format changes.
+
+### Solution
+**Two-phase parsing:**
+
+1. **Header Detection** (lines 217-230):
+```python
+if "[ ID]" in line and "Interval" in line:
+    columns = line.split()
+    for i, col in enumerate(columns):
+        if "Interval" in col:
+            col_interval = i
+        elif "Bitrate" in col:
+            col_bitrate = i
+        elif "Lost/Total" in col:
+            col_lost_total = i
+        elif "Retr" in col:
+            col_retr = i
+```
+
+2. **Dynamic Data Extraction** (lines 268-278 for bitrate example):
+```python
+# Find bitrate value by searching for "bits/sec" pattern
+for i in range(len(columns) - 1):
+    if 'bits/sec' in columns[i + 1]:
+        bitrate = float(columns[i])
+        bitrate_unit_idx = i + 1
+        break
+```
+
+**Why two-phase?**
+- Header columns don't match data column positions
+- Header: `Bitrate` is one word at index N
+- Data: `199045 Kbits/sec` is two words spanning multiple indices
+- Solution: Use header to understand structure, then search data for patterns
+
+### Column Finding Strategies
+
+| Metric | Header Hint | Data Search Pattern | Notes |
+|--------|-------------|---------------------|-------|
+| Interval | `col_interval` | Use header index directly | Reliable position |
+| Bitrate | `col_bitrate` | Find `'bits/sec'` in next column | Value before unit |
+| Lost/Total | `col_lost_total` | Find `/` pattern (excluding `bits/sec`) | Format: `0/20735` |
+| Retr | `col_retr` | Use header index if available | TCP sender only |
+
+## iperf Output Formats
+
+This section shows actual iperf3 output examples for different modes to help understand what the post-processor parses.
+
+### TCP Unidirectional - TX Side (Client)
+
+**File**: `iperf-client-result.txt`
+
+**Header format**: `[ ID] Interval Transfer Bitrate Retr Cwnd`
+
+**Key characteristics**:
+- `Retr` column present (identifies TCP sender)
+- Generates `tx-Gbps` and `tx-retry/sec` metrics
+
+**Example output**:
+```
+BEGIN-TS-0 1779554823.073021327
+Connecting to host 172.30.39.93, port 30002
+[  5] local 10.131.0.80 port 53526 connected to 172.30.39.93 port 30002
+[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5]   0.00-1.00   sec   560 MBytes  4696000 Kbits/sec   64    924 KBytes
+[  5]   1.00-2.00   sec   537 MBytes  4506472 Kbits/sec    0    968 KBytes
+[  5]   2.00-3.00   sec   537 MBytes  4503413 Kbits/sec    0    982 KBytes
+...
+END-TS-0 1779554883.072978496
+```
+
+### TCP Unidirectional - RX Side (Server)
+
+**File**: `iperf-server-result.txt`
+
+**Header format**: `[ ID] Interval Transfer Bitrate`
+
+**Key characteristics**:
+- No `Retr` column (identifies TCP receiver)
+- Generates `rx-Gbps` metric
+- Timestamps read from client file at `../../client/1/iperf-client-result.txt`
+
+**Example output**:
+```
+BEGIN-TS-0 1779554780.163774594
+-----------------------------------------------------------
+Server listening on 30002 (test #1)
+-----------------------------------------------------------
+Accepted connection from 10.131.0.80, port 53522
+[  5] local 10.128.2.58 port 30002 connected to 10.131.0.80 port 53526
+[ ID] Interval           Transfer     Bitrate
+[  5]   0.00-1.00   sec   558 MBytes  4676843 Kbits/sec
+[  5]   1.00-2.00   sec   537 MBytes  4504919 Kbits/sec
+[  5]   2.00-3.00   sec   537 MBytes  4504719 Kbits/sec
+...
+```
+
+**Note**: Server output does NOT contain BEGIN-TS/END-TS markers - timestamps are always read from the client result file for clock synchronization.
+
+### TCP Bidirectional Mode
+
+**File**: `iperf-client-result.txt` (using `--bidir` flag)
+
+**Header format**: `[ ID][Role] Interval Transfer Bitrate Retr Cwnd`
+
+**Key characteristics**:
+- Role markers in brackets: `[TX-C]`, `[RX-C]`, `[TX-S]`, `[RX-S]`
+- Multiple connection IDs (one for TX, one for RX)
+- Post-processor detects bidirectional mode from role markers
+- Generates both `tx-Gbps` and `rx-Gbps` metrics
+
+**Example output**:
+```
+BEGIN-TS-0 1779563482.253489588
+Connecting to host 172.30.144.25, port 30002
+[  5] local 10.131.0.84 port 46620 connected to 172.30.144.25 port 30002
+[  7] local 10.131.0.84 port 46632 connected to 172.30.144.25 port 30002
+[ ID][Role] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5][TX-C]   0.00-1.00   sec  59.6 MBytes  499619 Kbits/sec    0    207 KBytes       (omitted)
+[  7][RX-C]   0.00-1.00   sec  59.6 MBytes  499614 Kbits/sec                  (omitted)
+[  5][TX-C]   1.00-2.00   sec  59.6 MBytes  499904 Kbits/sec    0    207 KBytes       (omitted)
+[  7][RX-C]   1.00-2.00   sec  59.6 MBytes  499904 Kbits/sec                  (omitted)
+[  5][TX-C]   0.00-1.00   sec  59.6 MBytes  499905 Kbits/sec    0    207 KBytes
+[  7][RX-C]   0.00-1.00   sec  59.6 MBytes  499829 Kbits/sec
+[  5][TX-C]   1.00-2.00   sec  59.6 MBytes  500175 Kbits/sec    0    207 KBytes
+[  7][RX-C]   1.00-2.00   sec  59.6 MBytes  499988 Kbits/sec
+...
+END-TS-0 1779563542.253489588
+```
+
+**Role marker meanings**:
+- `TX-C` - Client transmitting (generates tx-Gbps, tx-retry/sec)
+- `RX-C` - Client receiving (generates rx-Gbps)
+- `TX-S` - Server transmitting (in server output file)
+- `RX-S` - Server receiving (in server output file)
+
+**Processing details**:
+- Post-processor aggregates TX and RX samples separately by timestamp
+- Samples with same timestamp are grouped: `(begin_ts, end_ts) -> {tx: [values], rx: [values]}`
+- Both TX and RX metrics are logged for the same time intervals
+
+### UDP Sender
+
+**Header format**: `[ ID] Interval Transfer Bitrate Total Datagrams`
+
+**Key characteristics**:
+- `Datagrams` column present
+- No `Lost/Total` column (identifies sender)
+- Generates `tx-Gbps` metric
+
+### UDP Receiver
+
+**Header format**: `[ ID] Interval Transfer Bitrate Jitter Lost/Total Datagrams`
+
+**Key characteristics**:
+- `Lost/Total` column present (identifies receiver)
+- `Datagrams` column present
+- Generates `rx-Gbps`, `rx-lost/sec`, and `rx-pps` metrics
+
+**Example Lost/Total parsing**:
+```
+[  5]   0.00-1.00   sec  59.6 MBytes  499904 Kbits/sec  0.012 ms  0/42850 (0%)
+```
+- Lost: `0` packets
+- Total: `42850` packets
+- Loss percentage: `0%`
+
+## Hunter Mode Processing
+
+### Overview
+Hunter mode runs multiple iperf tests with different bitrates to find the optimal throughput without packet loss.
+
+### Client-Side Hunter Logic
+
+**Input**: `iperf-client-result.txt` with multiple test runs
+```
+BEGIN-TS-1 1779449520.123456789
+[iperf output for run 1]
+END-TS-1 1779449530.234567890
+
+BEGIN-TS-2 1779449540.345678901
+[iperf output for run 2]
+END-TS-2 1779449550.456789012
+...
+```
+
+**Selection Algorithm** (lines 89-129):
+```python
+highest_bitrate = 0
+highest_run_number = 0
+cur_run_number = 0
+
+for line in fh:
+    if "BEGIN-TS" in line:
+        cur_run_number += 1
+    if "PASS" in line:
+        columns = line.split()
+        bitrate = float(columns[8])  # e.g., "149987" from "149987 Kbits/sec"
+        if bitrate > highest_bitrate:
+            highest_bitrate = bitrate
+            highest_run_number = cur_run_number
+```
+
+**PASS Line Format**:
+```
+PASS: [  5]   0.00-10.00  sec   179 MBytes  149987 Kbits/sec  0.007 ms  0/207293 (0%)  receiver
+```
+- Column 8 contains the bitrate value
+- PASS indicates zero packet loss
+- Selects run with highest bitrate among all PASS runs
+
+**Output**: `hunt-temp-result.txt` containing only the selected run
+```
+BEGIN-TS-7 1779449620.867662429
+[iperf output for run 7 only]
+END-TS-7 1779449633.875724949
+```
+
+### Server-Side Hunter Logic
+
+**Challenge**: Server result file contains continuous output from all tests:
+```
+Server listening on 30001 (test #1)
+[run 1 output]
+Server listening on 30002 (test #2)
+[run 2 output]
+...
+Server listening on 30007 (test #7)
+[run 7 output]
+...
+```
+
+**Solution** (lines 64-87, 132-185):
+
+1. **Read client's selection**:
+```python
+client_hunt_result = "../../client/1/hunt-temp-result.txt"
+with open(client_hunt_result, 'r') as fh:
+    first_line = fh.readline()
+    # Extract: "BEGIN-TS-7" → run number = 7
+    match = re.search(r'BEGIN-TS-(\d+)', first_line)
+    selected_run = int(match.group(1))
+```
+
+2. **Extract matching test from server results**:
+```python
+target_marker = f"(test #{test_number})"
+next_test_marker = f"(test #{test_number + 1})"
+in_target_test = False
+
+for line in fh:
+    if target_marker in line:
+        in_target_test = True
+        continue  # Skip "Server listening" line
+
+    if in_target_test:
+        if next_test_marker in line or "END-TS" in line:
+            break
+        ofh.write(line)
+```
+
+3. **Add timestamps from client**:
+```python
+# Read BEGIN-TS-N and END-TS-N from client hunt-temp-result.txt
+client_hunt = "../../client/1/hunt-temp-result.txt"
+with open(client_hunt, 'r') as cfh:
+    for line in cfh:
+        if f"BEGIN-TS-{test_number}" in line:
+            begin_ts = line.strip()
+        elif f"END-TS-{test_number}" in line:
+            end_ts = line.strip()
+
+# Prepend/append to extracted server output
+ofh.write(begin_ts + "\n")
+[server output for test N]
+ofh.write(end_ts + "\n")
+```
+
+**Critical**: Server must extract the SAME run number that client selected, ensuring metric alignment.
+
+### Hunter Mode Directory Structure
+
+```
+<run-dir>/
+├── client/1/
+│   ├── iperf-client-result.txt       # All runs with BEGIN-TS-N/END-TS-N markers
+│   ├── hunt-temp-result.txt          # Selected run only (created by pre_process_hunting_results)
+│   └── metric-data-0.{json,csv}.xz   # Metrics from selected run
+└── server/1/
+    ├── iperf-server-result.txt       # All tests concatenated
+    ├── hunt-temp-result.txt          # Extracted test matching client selection
+    └── metric-data-0.{json,csv}.xz   # Metrics from matching test
+```
+
+## Metric Types Collected
+
+### UDP Metrics
+
+| Metric Type | Source | Description | When Available |
+|-------------|--------|-------------|----------------|
+| tx-Gbps | Client | Transmit throughput | Sender side |
+| rx-Gbps | Server | Receive throughput | Receiver side |
+| rx-pps | Server | Packets per second | Receiver side (from Total) |
+| rx-lost/sec | Server | Dropped packets per second | Receiver side (from Lost) |
+
+**UDP Lost/Total Parsing** (lines 290-342):
+```python
+# Find Lost/Total column by searching for X/Y pattern
+for i, col in enumerate(columns):
+    if "/" in col and "bits/sec" not in col:
+        lost_total_idx = i
+        break
+
+# Example: "0/20735(0%)" or "0/20735 (0%)"
+lost_total = columns[lost_total_idx]
+lost_total_clean = lost_total.split("(")[0]  # Remove "(0%)" part
+parts = lost_total_clean.split("/")
+lost = int(parts[0])   # 0
+total = int(parts[1])  # 20735
+```
+
+**Logging order matters** for idx assignment:
+```python
+# rx-pps logged FIRST → idx=0 (if rx-lost/sec filtered)
+metrics.log_sample("0", {"type": "rx-pps"}, names, s)
+
+# rx-lost/sec logged SECOND → idx=0 (if kept), idx=1 (if rx-pps exists)
+metrics.log_sample("0", {"type": "rx-lost/sec"}, names, s)
+
+# rx-Gbps logged THIRD
+metrics.log_sample("0", {"type": primary_metric}, names, s)
+```
+
+### TCP Metrics
+
+| Metric Type | Source | Description | When Available |
+|-------------|--------|-------------|----------------|
+| tx-Gbps | Client | Transmit throughput | Sender side |
+| rx-Gbps | Server | Receive throughput | Receiver side |
+| tx-retry/sec | Client | TCP retransmits | Sender side (Retr column) |
+
+**TCP Retry Parsing** (lines 400-412):
+```python
+# Check for retry field using header-based index
+if col_retr is not None and col_retr < len(columns):
+    try:
+        retry = int(columns[col_retr])
+        is_tx = True
+
+        desc = {"source": "iperf", "class": "count", "type": "tx-retry/sec"}
+        s = {"begin": int(ts), "end": int(ts_end), "value": retry}
+        metrics.log_sample("0", desc, names, s)
+    except (ValueError, IndexError):
+        pass
+```
+
+### Bidirectional Mode
+
+**Detection** (lines 356-362):
+```python
+role = extract_role(line)  # Extract from "[ ID][TX-C]" pattern
+if role and not bidir_mode:
+    bidir_mode = True
+    print("BIDIRECTIONAL MODE DETECTED from role markers in output")
+```
+
+**Role Markers**:
+- `TX-C` / `RX-C` - Client transmit/receive
+- `TX-S` / `RX-S` - Server transmit/receive
+
+**Aggregation** (lines 415-442):
+```python
+# Determine metric type from role
+metric_type = 'tx-Gbps' if role.startswith('TX') else 'rx-Gbps'
+
+# Accumulate samples by timestamp
+key = (int(ts), int(ts_end))
+if key not in throughput_samples:
+    throughput_samples[key] = {}
+throughput_samples[key][metric_type] += throughput_value
+```
+
+**Logging** (lines 462-470):
+```python
+# After processing all lines, log accumulated samples
+for (begin_ts, end_ts), metrics_dict in sorted(throughput_samples.items()):
+    for metric_type, value in metrics_dict.items():
+        desc = {"source": "iperf", "class": "throughput", "type": metric_type}
+        s = {"begin": begin_ts, "end": end_ts, "value": value}
+        metrics.log_sample("0", desc, names, s)
+```
+
+## CDMMetrics Integration
+
+### Zero-Value Handling
+
+**Flag**: `dont_delete=True` (line 464)
+```python
+metric_data_name = metrics.finish_samples(dont_delete=True)
+```
+
+**Why needed**:
+- CDMMetrics default behavior: Filter out metrics where ALL values are 0
+- Problem: rx-lost/sec = 0 means "no packet loss" (good), not "no data" (missing)
+- Solution: `dont_delete=True` preserves zero-value metrics
+- Benefit: Consistent metric schema regardless of packet loss/retransmits
+
+**Without dont_delete=True**:
+```
+# Zero packet loss run
+source: iperf
+  types: rx-Gbps rx-pps tx-Gbps
+  # rx-lost/sec MISSING!
+```
+
+**With dont_delete=True**:
+```
+# Zero packet loss run
+source: iperf
+  types: rx-Gbps rx-lost/sec rx-pps tx-Gbps
+  # rx-lost/sec present with value 0.00
+```
+
+### Index Assignment
+
+CDMMetrics assigns indices sequentially based on first log_sample() call order:
+
+```python
+# First unique metric logged → idx=0
+metrics.log_sample("0", {"type": "rx-lost/sec"}, ...)  # idx=0
+
+# Second unique metric logged → idx=1
+metrics.log_sample("0", {"type": "rx-pps"}, ...)       # idx=1
+
+# Third unique metric logged → idx=2
+metrics.log_sample("0", {"type": "rx-Gbps"}, ...)      # idx=2
+```
+
+**Output**: `metric-data-0.json.xz`
+```json
+[
+  {"idx": 0, "desc": {"type": "rx-lost/sec"}, ...},
+  {"idx": 1, "desc": {"type": "rx-pps"}, ...},
+  {"idx": 2, "desc": {"type": "rx-Gbps"}, ...}
+]
+```
+
+**Output**: `metric-data-0.csv.xz`
+```
+0,1779449620867,1779449621866,0
+1,1779449620867,1779449621866,20735
+2,1779449620867,1779449621866,0.199045
+0,1779449621867,1779449622866,0
+1,1779449621867,1779449622866,20729
+2,1779449621867,1779449622866,0.198997
+```
+
+Format: `idx,begin_timestamp,end_timestamp,value`
+
+### Sample Aggregation
+
+CDMMetrics deduplicates consecutive samples with identical values:
+
+```python
+# Input: 10 samples of rx-lost/sec, all with value=0
+log_sample("0", {"type": "rx-lost/sec"}, {"begin": 1000, "end": 1999, "value": 0})
+log_sample("0", {"type": "rx-lost/sec"}, {"begin": 2000, "end": 2999, "value": 0})
+log_sample("0", {"type": "rx-lost/sec"}, {"begin": 3000, "end": 3999, "value": 0})
+# ... 7 more samples with value=0
+
+# Output: 1 aggregated sample spanning entire period
+# CSV: 0,1000,9999,0
+```
+
+**When aggregation happens**:
+- Same idx
+- Same value
+- Consecutive timestamps
+
+**Why this matters**:
+- Reduces storage for stable metrics
+- Maintains time coverage
+- Query results show aggregated value over longer period
+
+## Primary Metric Selection
+
+The `primary-metric` field in `post-process-data.json` determines which metric appears in summary reports.
+
+**Selection Logic** (lines 326-335, 418-430, 474-476):
+
+1. **UDP Receiver** (has Lost/Total):
+   ```python
+   if primary_metric is None:
+       primary_metric = "rx-Gbps"
+   ```
+
+2. **UDP Sender** (no Lost/Total):
+   ```python
+   primary_metric = "tx-Gbps"
+   ```
+
+3. **TCP Receiver** (first RX sample):
+   ```python
+   if primary_metric is None and metric_type == 'rx-Gbps':
+       primary_metric = 'rx-Gbps'
+   ```
+
+4. **TCP Sender** (has Retr):
+   ```python
+   metric_type = "tx-Gbps"
+   ```
+
+5. **Default fallback**:
+   ```python
+   if primary_metric is None:
+       primary_metric = "rx-Gbps"
+   ```
+
+**Output**: `post-process-data.json`
+```json
+{
+  "benchmark": "iperf",
+  "primary-period": "measurement",
+  "primary-metric": "rx-Gbps",
+  "periods": [
+    {
+      "name": "measurement",
+      "metric-files": ["metric-data-0"]
+    }
+  ]
+}
+```
+
+## Validation Wrapper
+
+**Purpose**: `iperf-post-process-with-validation.py` validates new code against upstream
+
+**Workflow**:
+```
+1. Run NEW post-process (iperf-post-process.py)
+2. Save outputs as *.new
+3. Run UPSTREAM post-process (upstream-iperf-post-process.py)
+4. Compare outputs
+5. Restore NEW outputs for rickshaw indexing
+```
+
+**Validation Report** (lines 79-210):
+```
+POST-PROCESS VALIDATION REPORT
+Role: SERVER
+
+Metric Types:
+  NEW:      ['rx-Gbps', 'rx-lost/sec', 'rx-pps']
+  UPSTREAM: ['rx-Gbps', 'rx-pps']
+
+Server Comparison:
+  rx-Gbps: PASS (7 samples match)
+  rx-lost/sec: SKIP (not in upstream output)
+  rx-pps: PASS (7 samples match)
+```
+
+**When to remove validation**:
+After sufficient testing, update `rickshaw.json`:
+```json
+"post-script": "%bench-dir%iperf-post-process.py"
+```
+Instead of:
+```json
+"post-script": "%bench-dir%iperf-post-process-with-validation.py"
+```
+
+## Common Issues and Solutions
+
+### Issue 1: Stale Uncompressed JSON Files
+
+**Symptom**: `KeyError: 0` during indexing, metrics missing from OpenSearch
+
+**Root Cause**: rickshaw-gen-docs.py creates uncompressed `metric-data-0.json` when adding UUIDs. If post-processing reruns, it reads the stale uncompressed file instead of the updated compressed file.
+
+**Solution**:
+```bash
+rm -f <run-dir>/run/iterations/*/sample-*/*/1/metric-data-0.json
+crucible index <run-dir>
+```
+
+**Prevention**: This is a known rickshaw issue being tracked upstream.
+
+### Issue 2: Race Conditions in Hunter Mode Post-Processing
+
+There are TWO race conditions when client and server post-processing run in parallel:
+
+#### Race Condition 2a: File Not Created Yet
+
+**Symptom**: Server post-processing fails with "No PASS found", server hunt-temp-result.txt contains all tests instead of selected test
+
+**Root Cause**: Server post-processing started before client created hunt-temp-result.txt
+
+**What happens**:
+1. Rickshaw may run client and server post-processing in parallel
+2. Server checks for `../../client/1/hunt-temp-result.txt` (line 80-91)
+3. File doesn't exist yet, so check fails
+4. Falls through to client-side hunting logic (lines 109-149)
+5. Client logic looks for PASS lines - but server output has no PASS lines
+6. Defaults to "last run" which is actually run 0 (the entire server result file)
+7. Calls `dup_one_run()` which copies from BEGIN-TS-0 to END-TS-0 (all tests)
+
+**Solution**: Server waits up to 30 seconds for client hunt-temp-result.txt to appear (implemented in lines 80-91). If file doesn't appear, post-processing exits with error instead of producing incorrect output.
+
+**Error message if timeout**:
+```
+ERROR: Server hunting mode requires ../../client/1/hunt-temp-result.txt to exist
+Waited 30 seconds but file was not created
+Client post-processing must complete first to create this file
+```
+
+#### Race Condition 2b: Partial File Read
+
+**Symptom**: Server reads incomplete hunt-temp-result.txt, may fail to extract run number or get truncated test data
+
+**Root Cause**: Server passes `os.path.exists()` check while client is still writing the file
+
+**What happens**:
+1. Client opens hunt-temp-result.txt for writing
+2. Client writes first few lines
+3. File exists on disk but isn't fully written yet
+4. Server's `os.path.exists()` check returns True
+5. Server opens and reads the incomplete file
+6. Regex might not find `BEGIN-TS-(\d+)` pattern
+7. Or server gets partial test data missing END-TS marker
+
+**Solution**: Client uses atomic write-then-rename pattern (implemented in `dup_one_run()` at lines 55-67 and `extract_server_test()` at lines 191-219):
+```python
+# Write to temp file first
+temp_file = outfile + ".tmp"
+with open(temp_file, "w") as ofh:
+    # ... write all data ...
+
+# Atomic rename - file appears complete or not at all
+os.rename(temp_file, outfile)
+```
+
+**How this prevents the race**:
+- Client writes to `hunt-temp-result.txt.tmp`
+- Server's `os.path.exists("hunt-temp-result.txt")` returns False during writing
+- Client finishes writing, calls atomic `os.rename()`
+- File instantly appears complete (filesystems guarantee rename atomicity)
+- Server sees file only after it's fully written
+
+### Issue 3: Header Column Indices Don't Match Data
+
+**Symptom**: Wrong values extracted, or ValueError when parsing
+
+**Root Cause**: Header columns are single words, data has value+unit pairs
+
+**Example**:
+```
+Header: [ ID] Interval Transfer Bitrate Jitter Lost/Total
+Index:    0      1         2        3       4        5
+
+Data:   [  5] 0.00-1.00 sec  23.7 MBytes 199045 Kbits/sec  0.011 ms 0/20735 (0%)
+Index:    0      1      2    3     4       5       6        7    8    9      10
+```
+
+Header index 5 = "Lost/Total", but data index 9 = "0/20735"
+
+**Solution**: Use header for structure understanding, search data for patterns (implemented in lines 217-342)
+
+### Issue 4: Embedded Server Output in Client File
+
+**Symptom**: Server metrics appear in client output when using `--get-server-output`
+
+**Detection** (lines 233-236):
+```python
+if line == "Server output:":
+    print("Detected embedded server output - stopping client processing")
+    break
+```
+
+**Why**: Prevent double-counting metrics. Server data processed separately from server-result.txt.
+
+### Issue 5: Omitted Samples Inclusion
+
+**Symptom**: More samples than expected, metrics include warm-up period
+
+**Detection** (lines 247-248):
+```python
+if "omitted" in line:
+    continue
+```
+
+**Why**: iperf uses `--omit N` to exclude first N seconds from statistics. Lines marked `(omitted)` should not generate metrics.
+
+## Testing Guidelines
+
+### Test Hunter Mode
+```bash
+# Run hunter test
+crucible run hunter-test.json
+
+# Find result directory
+crucible ls | grep iperf | head -1
+
+# Check post-process output
+cat <run-dir>/run/iterations/iteration-1/sample-1/server/1/post-process-output.txt
+
+# Verify:
+# 1. "Client selected run N" message
+# 2. "Extracted test #N from server results"
+# 3. Same N on client and server
+```
+
+### Test Zero-Value Metrics
+```bash
+# Run clean UDP test (no packet loss)
+crucible run clean-udp.json
+
+# Get result
+crucible get result --run <run-id>
+
+# Verify rx-lost/sec appears in metrics list
+# Query it
+crucible get metric --run <run-id> --source iperf --type rx-lost/sec --period <period-id>
+
+# Should show 0.00 value, not missing
+```
+
+### Test Bidirectional Mode
+```bash
+# Run bidir test
+crucible run bidir.json
+
+# Check post-process output for:
+# "BIDIRECTIONAL MODE DETECTED from role markers in output"
+
+# Verify result has both tx-Gbps and rx-Gbps
+crucible get result --run <run-id>
+```
+
+### Validate Against Upstream
+```bash
+# Ensure rickshaw.json uses validation wrapper
+# Run test
+crucible run test.json
+
+# Check validation report in post-process-output.txt
+cat <run-dir>/run/iterations/iteration-1/sample-1/*/1/post-process-output.txt
+
+# Look for "POST-PROCESS VALIDATION REPORT"
+# Verify PASS for common metrics
+```
+
+## Performance Considerations
+
+### Metric Storage
+- Each sample: ~40 bytes in CSV (idx,begin,end,value)
+- 10-second test @ 1 sample/sec × 3 metrics = 30 samples = ~1.2 KB
+- Aggregation reduces storage for stable values
+- Zero-filtering saved ~33% storage (now disabled with dont_delete=True)
+
+### Indexing Time
+- Primary bottleneck: OpenSearch document generation
+- ~0.1 sec per metric descriptor (UUID assignment)
+- ~0.01 sec per metric data sample
+- Hunter mode: Only selected run indexed, not all attempts
+
+### Memory Usage
+- iperf output: ~10 KB per test
+- Hunter mode: ~10 KB × 10 runs = ~100 KB
+- Post-processing peak: ~1 MB (includes CDMMetrics buffers)
+- No special optimization needed for typical tests
+
+## Future Enhancements
+
+### Potential Improvements
+1. **Multi-stream aggregation**: Sum bitrates across parallel streams
+2. **Jitter metrics**: Parse and index jitter values from UDP receiver
+3. **Congestion window tracking**: Extract cwnd from TCP output
+4. **Per-stream breakouts**: Index individual stream performance
+5. **Packet size distribution**: Histogram of packet sizes if iperf provides it
+
+### Backward Compatibility
+When adding new metrics:
+1. Keep existing metric types unchanged
+2. Add new types with distinct names
+3. Preserve idx assignment order
+4. Test with validation wrapper
+5. Ensure dont_delete=True applies to new metrics
+
+### Known Limitations
+1. **Assumes single iperf instance per endpoint**: Multiple parallel iperf processes not supported
+2. **No partial failure handling**: If one sample parsing fails, entire run may be affected
+3. **Fixed timestamp source**: Always uses client timestamps, no fallback if unavailable
+4. **No schema evolution**: Metric descriptors are static once logged
+
+## References
+
+- **CDMMetrics**: `/opt/crucible/repos/https:github.com:perftool-incubator/toolbox/python/toolbox/cdm_metrics.py`
+- **rickshaw-gen-docs**: `/opt/crucible/subprojects/core/rickshaw/rickshaw-gen-docs.py`
+- **iperf3 documentation**: https://iperf.fr/iperf-doc.php
+- **CDM schema**: `/opt/crucible/repos/https:github.com:perftool-incubator/CommonDataModel/`
+
+## Document Version
+
+- **Created**: 2026-05-22
+- **Last Updated**: 2026-05-22
+- **Code Version**: Post header-based parsing implementation, hunter mode server sync, zero-value preservation
+- **Author**: Claude (AI assistant session summary)

--- a/unit-test/README-TESTING.md
+++ b/unit-test/README-TESTING.md
@@ -1,0 +1,121 @@
+# iperf Post-Processor Testing
+
+## Setup
+
+First-time setup - create the Python virtual environment:
+
+```bash
+cd /opt/crucible/subprojects/benchmarks/iperf/unit-test
+./bootstrap.sh
+```
+
+Or using the resolved path:
+
+```bash
+cd /opt/crucible/repos/https:github.com:perftool-incubator/bench-iperf/unit-test
+./bootstrap.sh
+```
+
+This creates a local `.venv` directory with Python 3.11.
+
+## Running Tests
+
+After bootstrap, run the test suite:
+
+```bash
+cd /opt/crucible/subprojects/benchmarks/iperf/unit-test
+./run-tests.py
+```
+
+## Test Cases
+
+The test suite includes 8 test cases with real production data:
+
+1. **missing-timestamps** - Validates failure detection (missing BEGIN-TS/END-TS)
+2. **tcp-unidirectional-client** - TCP sender with tx-Gbps and tx-retry/sec
+3. **tcp-unidirectional-server** - TCP receiver with rx-Gbps (catches the bug we fixed!)
+4. **tcp-bidirectional-client** - TCP bidir client with tx-Gbps and rx-Gbps
+5. **tcp-bidirectional-server** - TCP bidir server with tx-Gbps and rx-Gbps
+6. **udp-sender** - UDP sender with tx-Gbps
+7. **udp-receiver** - UDP receiver with rx-Gbps, rx-lost/sec, rx-pps
+8. **tcp-hunter-mode** - Multiple bitrate runs with PASS/FAIL selection
+
+## What the Tests Validate
+
+- ✅ Script runs without Python errors
+- ✅ Success marker "POST-PROCESS-STATUS: success" appears in output
+- ✅ Failure detection works (missing-timestamps test)
+- ✅ All protocol/direction/mode combinations covered
+
+## Debugging Post-Processor Changes
+
+When you modify `iperf-post-process.py` and introduce a bug or want to test changes:
+
+### 1. Run the test suite to identify failures
+
+```bash
+cd /opt/crucible/subprojects/benchmarks/iperf/unit-test
+./run-tests.py
+```
+
+The test output shows which scenarios fail and displays STDOUT/STDERR from the post-processor.
+
+### 2. Debug a specific test case manually
+
+```bash
+cd /opt/crucible/subprojects/benchmarks/iperf/unit-test
+
+# Copy the failing test's data to parent directory
+cp test-data/tcp-unidirectional-server/iperf-server-result.txt ..
+cp test-data/tcp-unidirectional-server/iperf-client-result.txt ..
+
+# Run post-processor directly using the venv Python
+cd ..
+unit-test/.venv/bin/python3 iperf-post-process.py --protocol=tcp --ipv=4 --ifname=eth0
+```
+
+### 3. Iterate and fix
+
+- Make fixes to `iperf-post-process.py`
+- Re-run `./run-tests.py` from unit-test directory
+- All 8 tests should pass before committing changes
+
+### 4. Add new test cases for bug fixes
+
+If you fix a bug, add a test case to prevent regression:
+
+```bash
+cd /opt/crucible/subprojects/benchmarks/iperf/unit-test
+
+# Create new test case directory
+mkdir test-data/my-bug-fix-case
+
+# Copy relevant iperf result files from a real run
+cp /path/to/iperf-client-result.txt test-data/my-bug-fix-case/
+
+# Create expected-metrics.json
+cat > test-data/my-bug-fix-case/expected-metrics.json << 'EOF'
+{
+  "protocol": "tcp",
+  "expected_metrics": ["rx-Gbps"],
+  "description": "Description of what this test validates"
+}
+EOF
+```
+
+**Benefits:**
+- ✅ Fast feedback loop (no need for full crucible runs)
+- ✅ Tests 8 different scenarios automatically
+- ✅ Catches regressions before they reach production
+- ✅ Consistent local test environment
+
+## Refreshing Test Samples
+
+To update test samples from latest regulus runs:
+
+```bash
+cd /opt/crucible/subprojects/benchmarks/iperf/unit-test
+./extract-test-samples.sh
+```
+
+This extracts fresh samples from `/home/hnhan/JPMC/jpmc-regulus/2_GROUP/NO-PAO/4IP/` runs into `unit-test/test-data/`.

--- a/unit-test/bootstrap.sh
+++ b/unit-test/bootstrap.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# -*- mode: sh; indent-tabs-mode: nil; sh-basic-offset: 4 -*-
+# vim: autoindent tabstop=4 shiftwidth=4 expandtab softtabstop=4 filetype=bash
+
+# Bootstrap script for iperf post-processor test infrastructure
+# Creates a Python virtual environment with required dependencies
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+VENV_DIR="${SCRIPT_DIR}/.venv"
+PYTHON_VERSION="python3.11"
+
+echo "========================================"
+echo "iperf Post-Processor Test Bootstrap"
+echo "========================================"
+echo
+
+# Check if Python 3.11 is available
+if ! command -v ${PYTHON_VERSION} &> /dev/null; then
+    echo "ERROR: ${PYTHON_VERSION} not found"
+    echo "Please install Python 3.11 or higher"
+    exit 1
+fi
+
+# Create venv if it doesn't exist
+if [ -d "${VENV_DIR}" ]; then
+    echo "I am using existing venv at ${VENV_DIR}"
+    echo "To recreate, delete it first: rm -rf ${VENV_DIR}"
+else
+    echo "Creating Python virtual environment at ${VENV_DIR}"
+
+    # Python venv refuses to create in paths with colons (like GitHub URLs)
+    # Workaround: Use virtualenv if available, otherwise use symlink-free path via /opt/crucible/subprojects
+    if command -v virtualenv &> /dev/null; then
+        virtualenv -p ${PYTHON_VERSION} "${VENV_DIR}"
+    else
+        # Try to find symlink-free path
+        SYMLINK_FREE_DIR="/opt/crucible/subprojects/benchmarks/iperf/unit-test/.venv"
+        if [ -d "/opt/crucible/subprojects/benchmarks/iperf" ]; then
+            echo "Using symlink-free path for venv creation"
+            ${PYTHON_VERSION} -m venv "${SYMLINK_FREE_DIR}"
+            # Create symlink from repos path to subprojects path if different
+            if [ "${VENV_DIR}" != "${SYMLINK_FREE_DIR}" ]; then
+                ln -s "${SYMLINK_FREE_DIR}" "${VENV_DIR}"
+            fi
+        else
+            echo "ERROR: Cannot create venv - path contains ':' (PATH separator)"
+            echo "Install virtualenv: pip install virtualenv"
+            echo "Or use the symlink path: /opt/crucible/subprojects/benchmarks/iperf/unit-test/"
+            exit 1
+        fi
+    fi
+    echo "Virtual environment created successfully"
+fi
+
+echo
+echo "========================================"
+echo "Setup complete!"
+echo "========================================"
+echo
+echo "To run tests:"
+echo "  cd ${SCRIPT_DIR}"
+echo "  ./run-tests.py"
+echo

--- a/unit-test/extract-test-samples.sh
+++ b/unit-test/extract-test-samples.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Extract test samples from regulus runs
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TESTDIR="$SCRIPT_DIR/test-data"
+REGULUS_ROOT=/home/hnhan/JPMC/jpmc-regulus/2_GROUP
+
+echo "Extracting test samples to $TESTDIR"
+
+# 1. TCP Unidirectional Server (TCP receiver - no special columns)
+echo "1. TCP unidirectional server..."
+mkdir -p $TESTDIR/tcp-unidirectional-server
+cp $REGULUS_ROOT/NO-PAO/4IP/INTER-NODE/TCP/2-POD/run-DRY-2026-05-23-12:41:14/iperf--2026-05-23_16:41:21_UTC--6e7581ee-5edb-4b1f-aea7-8ef92d053f03/run/iterations/iteration-1/sample-1/server/1/iperf-server-result.txt \
+   $TESTDIR/tcp-unidirectional-server/
+cp $REGULUS_ROOT/NO-PAO/4IP/INTER-NODE/TCP/2-POD/run-DRY-2026-05-23-12:41:14/iperf--2026-05-23_16:41:21_UTC--6e7581ee-5edb-4b1f-aea7-8ef92d053f03/run/iterations/iteration-1/sample-1/client/1/iperf-client-result.txt \
+   $TESTDIR/tcp-unidirectional-server/
+cat > $TESTDIR/tcp-unidirectional-server/expected-metrics.json << 'EOF'
+{
+  "protocol": "tcp",
+  "expected_metrics": ["rx-Gbps"],
+  "description": "TCP receiver - should generate rx-Gbps only"
+}
+EOF
+
+# 2. TCP Unidirectional Client (TCP sender - has Retr column)
+echo "2. TCP unidirectional client..."
+mkdir -p $TESTDIR/tcp-unidirectional-client
+cp $REGULUS_ROOT/NO-PAO/4IP/INTER-NODE/TCP/2-POD/run-DRY-2026-05-23-12:41:14/iperf--2026-05-23_16:41:21_UTC--6e7581ee-5edb-4b1f-aea7-8ef92d053f03/run/iterations/iteration-1/sample-1/client/1/iperf-client-result.txt \
+   $TESTDIR/tcp-unidirectional-client/
+cat > $TESTDIR/tcp-unidirectional-client/expected-metrics.json << 'EOF'
+{
+  "protocol": "tcp",
+  "expected_metrics": ["tx-Gbps", "tx-retry/sec"],
+  "description": "TCP sender - should generate tx-Gbps and tx-retry/sec"
+}
+EOF
+
+# 3. UDP Sender (has Datagrams column)
+echo "3. UDP sender..."
+mkdir -p $TESTDIR/udp-sender
+cp $REGULUS_ROOT/NO-PAO/4IP/INTER-NODE/UDP/2-POD/run-DRY-ourchecking-2026-05-21-20:32:49/iperf--2026-05-22_00:33:02_UTC--1195f1f7-b07e-4fda-b17a-8bb7d3326fb5/run/iterations/iteration-1/sample-1/client/1/iperf-client-result.txt \
+   $TESTDIR/udp-sender/
+cat > $TESTDIR/udp-sender/expected-metrics.json << 'EOF'
+{
+  "protocol": "udp",
+  "expected_metrics": ["tx-Gbps"],
+  "description": "UDP sender - should generate tx-Gbps only"
+}
+EOF
+
+# 4. UDP Receiver (has Lost/Total column)
+echo "4. UDP receiver..."
+mkdir -p $TESTDIR/udp-receiver
+cp $REGULUS_ROOT/NO-PAO/4IP/INTER-NODE/UDP/2-POD/run-DRY-ourchecking-2026-05-21-20:32:49/iperf--2026-05-22_00:33:02_UTC--1195f1f7-b07e-4fda-b17a-8bb7d3326fb5/run/iterations/iteration-1/sample-1/server/1/iperf-server-result.txt \
+   $TESTDIR/udp-receiver/ 2>/dev/null || echo "  (UDP server result not found - may not collect server data)"
+cp $REGULUS_ROOT/NO-PAO/4IP/INTER-NODE/UDP/2-POD/run-DRY-ourchecking-2026-05-21-20:32:49/iperf--2026-05-22_00:33:02_UTC--1195f1f7-b07e-4fda-b17a-8bb7d3326fb5/run/iterations/iteration-1/sample-1/client/1/iperf-client-result.txt \
+   $TESTDIR/udp-receiver/
+cat > $TESTDIR/udp-receiver/expected-metrics.json << 'EOF'
+{
+  "protocol": "udp",
+  "expected_metrics": ["rx-Gbps", "rx-lost/sec", "rx-pps"],
+  "description": "UDP receiver - should generate rx-Gbps, rx-lost/sec, and rx-pps"
+}
+EOF
+
+# 5. TCP Bidirectional (from N-POD-STEPS/run-bidir)
+echo "5. TCP bidirectional..."
+BIDIR_RUN=$(find $REGULUS_ROOT -path "*/N-POD-STEPS/run-bidir-*" -type d | head -1)
+if [ -n "$BIDIR_RUN" ]; then
+    BIDIR_CLIENT=$(find "$BIDIR_RUN" -path "*/client/1/iperf-client-result.txt" | head -1)
+    BIDIR_SERVER=$(find "$BIDIR_RUN" -path "*/server/1/iperf-server-result.txt" | head -1)
+
+    if [ -f "$BIDIR_CLIENT" ] && grep -q "\[TX-C\]" "$BIDIR_CLIENT"; then
+        echo "  Found bidirectional client!"
+        mkdir -p $TESTDIR/tcp-bidirectional-client
+        cp "$BIDIR_CLIENT" $TESTDIR/tcp-bidirectional-client/
+        cat > $TESTDIR/tcp-bidirectional-client/expected-metrics.json << 'EOF'
+{
+  "protocol": "tcp",
+  "bidir": true,
+  "expected_metrics": ["tx-Gbps", "rx-Gbps", "tx-retry/sec"],
+  "description": "TCP bidirectional client - should aggregate tx-Gbps and rx-Gbps from [TX-C] and [RX-C] flows"
+}
+EOF
+    fi
+
+    if [ -f "$BIDIR_SERVER" ] && grep -q "\[TX-S\]" "$BIDIR_SERVER"; then
+        echo "  Found bidirectional server!"
+        mkdir -p $TESTDIR/tcp-bidirectional-server
+        cp "$BIDIR_SERVER" $TESTDIR/tcp-bidirectional-server/
+        cp "$BIDIR_CLIENT" $TESTDIR/tcp-bidirectional-server/iperf-client-result.txt
+        cat > $TESTDIR/tcp-bidirectional-server/expected-metrics.json << 'EOF'
+{
+  "protocol": "tcp",
+  "bidir": true,
+  "expected_metrics": ["tx-Gbps", "rx-Gbps", "tx-retry/sec"],
+  "description": "TCP bidirectional server - should aggregate tx-Gbps and rx-Gbps from [TX-S] and [RX-S] flows"
+}
+EOF
+    fi
+fi
+
+# 6. Find hunter mode run
+echo "6. Looking for hunter mode run..."
+HUNTER_RUN=$(find $REGULUS_ROOT -path "*HUNTER*/client/1/iperf-client-result.txt" | head -1)
+if [ -f "$HUNTER_RUN" ]; then
+    echo "  Found hunter mode run!"
+    mkdir -p $TESTDIR/tcp-hunter-mode
+    cp "$HUNTER_RUN" $TESTDIR/tcp-hunter-mode/iperf-client-result.txt
+    cat > $TESTDIR/tcp-hunter-mode/expected-metrics.json << 'EOF'
+{
+  "protocol": "tcp",
+  "hunter": true,
+  "expected_metrics": ["tx-Gbps", "tx-retry/sec"],
+  "description": "TCP hunter mode - should select highest passing run and generate tx-Gbps"
+}
+EOF
+fi
+
+echo ""
+echo "Test sample extraction complete!"
+echo "Test cases created:"
+ls -1 $TESTDIR/ | grep -v README

--- a/unit-test/run-tests.py
+++ b/unit-test/run-tests.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+Test runner for iperf post-processor
+
+Runs the post-processor against test samples and verifies expected metrics are generated.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.resolve()
+BENCH_IPERF_DIR = SCRIPT_DIR.parent
+TEST_DATA_DIR = SCRIPT_DIR / "test-data"
+POST_PROCESSOR = BENCH_IPERF_DIR / "iperf-post-process.py"
+VENV_DIR = SCRIPT_DIR / ".venv"
+
+# SCRIPT_DIR is already resolved (follows symlinks), so it points to the real repo path
+# This is important because the container sees /opt/crucible/repos/..., not /opt/crucible/subprojects/...
+REAL_SCRIPT_DIR = BENCH_IPERF_DIR
+
+def run_test_case(test_dir):
+    """Run post-processor on a test case and verify results"""
+    test_name = test_dir.name
+    print(f"\n{'='*60}")
+    print(f"Test: {test_name}")
+    print(f"{'='*60}")
+
+    # Load expected results
+    expected_file = test_dir / "expected-metrics.json"
+    if not expected_file.exists():
+        print(f"  SKIP: No expected-metrics.json found")
+        return None
+
+    with open(expected_file) as f:
+        expected = json.load(f)
+
+    print(f"  Description: {expected.get('description', 'N/A')}")
+    print(f"  Expected metrics: {expected['expected_metrics']}")
+
+    # Copy test files to the real script directory (where wrapper will run)
+    # Clean up any previous test artifacts first
+    for artifact in ["iperf-client-result.txt", "iperf-server-result.txt",
+                     "metric-data-*.json", "metric-data-*.csv*", "post-process-data.json"]:
+        for f in REAL_SCRIPT_DIR.glob(artifact):
+            f.unlink()
+
+    # Copy input files to real script directory
+    if (test_dir / "iperf-client-result.txt").exists():
+        shutil.copy(test_dir / "iperf-client-result.txt", REAL_SCRIPT_DIR)
+    if (test_dir / "iperf-server-result.txt").exists():
+        shutil.copy(test_dir / "iperf-server-result.txt", REAL_SCRIPT_DIR)
+
+    try:
+        # Determine protocol arg
+        protocol = expected.get('protocol', 'tcp')
+
+        # Run post-processor using Python 3.11 venv (no container needed)
+        # Set TOOLBOX_HOME and PYTHONPATH for imports to work
+        # Use /opt/crucible directly since REAL_SCRIPT_DIR resolves symlinks
+        venv_python = VENV_DIR / "bin" / "python3"
+        script_path = REAL_SCRIPT_DIR / "iperf-post-process.py"
+        toolbox_home = Path("/opt/crucible/subprojects/core/toolbox")
+
+        env = os.environ.copy()
+        env['TOOLBOX_HOME'] = str(toolbox_home)
+        env['PYTHONPATH'] = str(toolbox_home / "python")
+
+        cmd = [venv_python, str(script_path), f"--protocol={protocol}", "--ipv=4", "--ifname=eth0"]
+
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            cwd=str(REAL_SCRIPT_DIR),
+            env=env
+        )
+
+        # Check if this test should fail
+        should_fail = expected.get('should_fail', False)
+
+        # Check for success status in stdout
+        success_marker = "POST-PROCESS-STATUS: success"
+        processing_succeeded = success_marker in result.stdout
+
+        if should_fail:
+            if processing_succeeded:
+                # Should have failed but succeeded
+                print(f"  FAIL ✗ Expected failure but post-processor succeeded")
+                if result.stdout:
+                    print(f"  STDOUT:\n{result.stdout}")
+                return False
+            else:
+                # Correctly failed (no success marker)
+                print(f"  PASS ✓ (correctly failed - no success marker in output)")
+                if result.stdout:
+                    print(f"  STDOUT:\n{result.stdout}")
+                if result.stderr:
+                    print(f"  STDERR:\n{result.stderr}")
+                return True
+        else:
+            if not processing_succeeded:
+                # Expected success but no success marker
+                print(f"  FAIL ✗ Post-processor did not complete successfully")
+                if result.stdout:
+                    print(f"  STDOUT:\n{result.stdout}")
+                if result.stderr:
+                    print(f"  STDERR:\n{result.stderr}")
+                return False
+            else:
+                # Expected success and got success marker
+                print(f"  PASS ✓ (post-processor completed successfully)")
+                print(f"  Note: Expected metrics {expected['expected_metrics']} (not verified due to container isolation)")
+                return True
+
+    finally:
+        # Clean up test files from real script directory
+        for artifact in ["iperf-client-result.txt", "iperf-server-result.txt",
+                         "post-process-data.json"]:
+            artifact_path = REAL_SCRIPT_DIR / artifact
+            if artifact_path.exists():
+                artifact_path.unlink()
+        for pattern in ["metric-data-*.json", "metric-data-*.csv*"]:
+            for f in REAL_SCRIPT_DIR.glob(pattern):
+                f.unlink()
+
+def main():
+    """Run all tests"""
+    print("=" * 60)
+    print("iperf Post-Processor Test Suite")
+    print("=" * 60)
+
+    # Check if venv exists
+    venv_python = VENV_DIR / "bin" / "python3"
+    if not venv_python.exists():
+        print(f"ERROR: Python venv not found at {VENV_DIR}")
+        print(f"")
+        print(f"Run the bootstrap script first:")
+        print(f"  cd {SCRIPT_DIR}")
+        print(f"  ./bootstrap.sh")
+        sys.exit(1)
+
+    if not TEST_DATA_DIR.exists():
+        print(f"ERROR: Test data directory not found: {TEST_DATA_DIR}")
+        print("Run ./extract-test-samples.sh first")
+        sys.exit(1)
+
+    # Find all test cases
+    test_cases = [d for d in TEST_DATA_DIR.iterdir() if d.is_dir()]
+    test_cases.sort()
+
+    if not test_cases:
+        print(f"ERROR: No test cases found in {TEST_DATA_DIR}")
+        sys.exit(1)
+
+    print(f"\nFound {len(test_cases)} test cases")
+
+    # Run tests
+    results = {}
+    for test_dir in test_cases:
+        result = run_test_case(test_dir)
+        if result is not None:
+            results[test_dir.name] = result
+
+    # Summary
+    print("\n" + "=" * 60)
+    print("Test Summary")
+    print("=" * 60)
+
+    passed = sum(1 for r in results.values() if r)
+    failed = sum(1 for r in results.values() if not r)
+
+    for test_name, result in sorted(results.items()):
+        status = "PASS ✓" if result else "FAIL ✗"
+        print(f"  {test_name:40s} {status}")
+
+    print("\n" + "=" * 60)
+    print(f"Total: {len(results)}  Passed: {passed}  Failed: {failed}")
+    print("=" * 60)
+
+    # Exit code
+    sys.exit(0 if failed == 0 else 1)
+
+if __name__ == "__main__":
+    main()

--- a/unit-test/test-data/README.md
+++ b/unit-test/test-data/README.md
@@ -1,0 +1,75 @@
+# iperf Post-Processing Test Data
+
+This directory contains real iperf output samples extracted from regulus runs for manual and automated testing.
+
+## Test Cases
+
+### tcp-unidirectional-server
+- **File**: `iperf-server-result.txt`
+- **Header**: `[ ID] Interval Transfer Bitrate`
+- **Detection**: TCP receiver (no special columns)
+- **Expected metrics**: `rx-Gbps`
+- **Description**: Tests that TCP receiver (no "Retr", no "Lost/Total", no "Datagrams") correctly generates rx-Gbps
+
+### tcp-unidirectional-client
+- **File**: `iperf-client-result.txt`
+- **Header**: `[ ID] Interval Transfer Bitrate Retr Cwnd`
+- **Detection**: TCP sender (has "Retr")
+- **Expected metrics**: `tx-Gbps`, `tx-retry/sec`
+- **Description**: Tests that TCP sender with Retr column generates tx metrics
+
+### udp-sender
+- **File**: `iperf-client-result.txt`
+- **Header**: `[ ID] Interval Transfer Bitrate Total Datagrams`
+- **Detection**: UDP sender (has "Datagrams")
+- **Expected metrics**: `tx-Gbps`
+- **Description**: Tests that UDP sender with Datagrams column generates tx metrics
+
+### udp-receiver
+- **File**: Server data (if available)
+- **Header**: `[ ID] Interval Transfer Bitrate Jitter Lost/Total Datagrams`
+- **Detection**: UDP receiver (has "Lost/Total")
+- **Expected metrics**: `rx-Gbps`, `rx-lost/sec`, `rx-pps`
+- **Description**: Tests that UDP receiver with Lost/Total column generates rx metrics
+
+### tcp-bidirectional-client
+- **File**: `iperf-client-result.txt`
+- **Header**: `[ ID][Role] Interval Transfer Bitrate Retr Cwnd`
+- **Detection**: Bidirectional mode (has `[TX-C]` and `[RX-C]` role markers)
+- **Expected metrics**: `tx-Gbps`, `rx-Gbps`, `tx-retry/sec`
+- **Description**: Tests that bidirectional client aggregates [TX-C] and [RX-C] flows separately
+
+### tcp-bidirectional-server
+- **File**: `iperf-server-result.txt`
+- **Header**: `[ ID][Role] Interval Transfer Bitrate Retr Cwnd`
+- **Detection**: Bidirectional mode (has `[TX-S]` and `[RX-S]` role markers)
+- **Expected metrics**: `tx-Gbps`, `rx-Gbps`, `tx-retry/sec`
+- **Description**: Tests that bidirectional server aggregates [TX-S] and [RX-S] flows separately
+
+### tcp-hunter-mode
+- **File**: `iperf-client-result.txt`
+- **Description**: Tests hunter mode (multiple runs at different bitrates, selects highest passing)
+- **Expected**: Correctly selects highest passing bitrate run
+
+## Extracting Samples
+
+Run `./extract-test-samples.sh` to extract fresh samples from regulus runs.
+
+## Manual Testing
+
+To manually test a sample:
+
+```bash
+cd test-data/tcp-unidirectional-server
+crucible wrapper python3 ../../iperf-post-process.py --protocol=tcp --ipv=4 --ifname=eth0
+# Check post-process-output.txt for detection messages (written to container, may not appear on host)
+# Check metric-data-0.json for generated metrics (written to container, may not appear on host)
+```
+
+Note: Due to container file system isolation, output files may not be visible on the host. The test is successful if the command exits with code 0 and no errors are printed.
+
+## Regression Detection
+
+These samples caught the bug where TCP receiver (no special columns) was misidentified as UDP sender, causing server to generate `tx-Gbps` instead of `rx-Gbps`.
+
+The fix: Changed protocol detection from `not has_retr_column` to `has_lost_total_column or has_datagrams_column`.

--- a/unit-test/test-data/missing-timestamps/expected-metrics.json
+++ b/unit-test/test-data/missing-timestamps/expected-metrics.json
@@ -1,0 +1,6 @@
+{
+  "protocol": "tcp",
+  "should_fail": true,
+  "expected_metrics": [],
+  "description": "Missing BEGIN-TS/END-TS timestamps - should cause subprocess.run to fail with empty stdout"
+}

--- a/unit-test/test-data/missing-timestamps/iperf-client-result.txt
+++ b/unit-test/test-data/missing-timestamps/iperf-client-result.txt
@@ -1,0 +1,4 @@
+[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5]   0.00-1.00   sec  1.16 GBytes  9.99 Gbits/sec    0   3.01 MBytes
+[  5]   1.00-2.00   sec  1.16 GBytes  10.0 Gbits/sec    0   3.01 MBytes
+[  5]   2.00-3.00   sec  1.16 GBytes  10.0 Gbits/sec    0   3.01 MBytes

--- a/unit-test/test-data/tcp-bidirectional-client/expected-metrics.json
+++ b/unit-test/test-data/tcp-bidirectional-client/expected-metrics.json
@@ -1,0 +1,6 @@
+{
+  "protocol": "tcp",
+  "bidir": true,
+  "expected_metrics": ["tx-Gbps", "rx-Gbps", "tx-retry/sec"],
+  "description": "TCP bidirectional client - should aggregate tx-Gbps and rx-Gbps from [TX-C] and [RX-C] flows"
+}

--- a/unit-test/test-data/tcp-bidirectional-client/iperf-client-result.txt
+++ b/unit-test/test-data/tcp-bidirectional-client/iperf-client-result.txt
@@ -1,0 +1,80 @@
+BEGIN-TS-0 1779563482.253489588
+Connecting to host 172.30.144.25, port 30002
+[  5] local 10.131.0.84 port 46620 connected to 172.30.144.25 port 30002
+[  7] local 10.131.0.84 port 46632 connected to 172.30.144.25 port 30002
+[ ID][Role] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5][TX-C]   0.00-1.00   sec  59.6 MBytes  499619 Kbits/sec    0    207 KBytes       (omitted)
+[  7][RX-C]   0.00-1.00   sec  59.6 MBytes  499614 Kbits/sec                  (omitted)
+[  5][TX-C]   1.00-2.00   sec  59.6 MBytes  499904 Kbits/sec    0    207 KBytes       (omitted)
+[  7][RX-C]   1.00-2.00   sec  59.6 MBytes  499904 Kbits/sec                  (omitted)
+[  5][TX-C]   2.00-3.00   sec  59.6 MBytes  500175 Kbits/sec    0    207 KBytes       (omitted)
+[  7][RX-C]   2.00-3.00   sec  59.6 MBytes  500253 Kbits/sec                  (omitted)
+[  5][TX-C]   0.00-1.00   sec  59.6 MBytes  499905 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   0.00-1.00   sec  59.6 MBytes  499829 Kbits/sec                  
+[  5][TX-C]   1.00-2.00   sec  59.6 MBytes  500175 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   1.00-2.00   sec  59.6 MBytes  499988 Kbits/sec                  
+[  5][TX-C]   2.00-3.00   sec  59.6 MBytes  499908 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   2.00-3.00   sec  59.6 MBytes  500170 Kbits/sec                  
+[  5][TX-C]   3.00-4.00   sec  59.6 MBytes  499902 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   3.00-4.00   sec  59.6 MBytes  499823 Kbits/sec                  
+[  5][TX-C]   4.00-5.00   sec  59.6 MBytes  500171 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   4.00-5.00   sec  59.6 MBytes  500172 Kbits/sec                  
+[  5][TX-C]   5.00-6.00   sec  59.6 MBytes  499908 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   5.00-6.00   sec  59.6 MBytes  499908 Kbits/sec                  
+[  5][TX-C]   6.00-7.00   sec  59.6 MBytes  499909 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   6.00-7.00   sec  59.6 MBytes  499909 Kbits/sec                  
+[  5][TX-C]   7.00-8.00   sec  59.6 MBytes  500178 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   7.00-8.00   sec  59.6 MBytes  500256 Kbits/sec                  
+[  5][TX-C]   8.00-9.00   sec  59.6 MBytes  499902 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   8.00-9.00   sec  59.6 MBytes  499824 Kbits/sec                  
+[  5][TX-C]   9.00-10.00  sec  59.6 MBytes  499909 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   9.00-10.00  sec  59.6 MBytes  499909 Kbits/sec                  
+[  5][TX-C]  10.00-11.00  sec  59.6 MBytes  500171 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  10.00-11.00  sec  59.6 MBytes  500172 Kbits/sec                  
+[  5][TX-C]  11.00-12.00  sec  59.6 MBytes  499913 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  11.00-12.00  sec  59.6 MBytes  499915 Kbits/sec                  
+[  5][TX-C]  12.00-13.00  sec  59.6 MBytes  499908 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  12.00-13.00  sec  59.6 MBytes  499908 Kbits/sec                  
+[  5][TX-C]  13.00-14.00  sec  59.6 MBytes  500174 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  13.00-14.00  sec  59.6 MBytes  500248 Kbits/sec                  
+[  5][TX-C]  14.00-15.00  sec  59.6 MBytes  499901 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  14.00-15.00  sec  59.6 MBytes  499823 Kbits/sec                  
+[  5][TX-C]  15.00-16.00  sec  59.6 MBytes  499914 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  15.00-16.00  sec  59.6 MBytes  499917 Kbits/sec                  
+[  5][TX-C]  16.00-17.00  sec  59.6 MBytes  500171 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  16.00-17.00  sec  59.6 MBytes  500170 Kbits/sec                  
+[  5][TX-C]  17.00-18.00  sec  59.6 MBytes  499901 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  17.00-18.00  sec  59.6 MBytes  499901 Kbits/sec                  
+[  5][TX-C]  18.00-19.00  sec  59.6 MBytes  499912 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  18.00-19.00  sec  59.6 MBytes  499910 Kbits/sec                  
+[  5][TX-C]  19.00-20.00  sec  59.6 MBytes  500171 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  19.00-20.00  sec  59.6 MBytes  500171 Kbits/sec                  
+[  5][TX-C]  20.00-21.00  sec  59.6 MBytes  499912 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  20.00-21.00  sec  59.6 MBytes  499990 Kbits/sec                  
+[  5][TX-C]  21.00-22.00  sec  59.6 MBytes  499904 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  21.00-22.00  sec  59.6 MBytes  499826 Kbits/sec                  
+[  5][TX-C]  22.00-23.00  sec  59.6 MBytes  500169 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  22.00-23.00  sec  59.6 MBytes  500172 Kbits/sec                  
+[  5][TX-C]  23.00-24.00  sec  59.6 MBytes  499913 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  23.00-24.00  sec  59.6 MBytes  500008 Kbits/sec                  
+[  5][TX-C]  24.00-25.00  sec  59.6 MBytes  499907 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  24.00-25.00  sec  59.6 MBytes  499790 Kbits/sec                  
+[  5][TX-C]  25.00-26.00  sec  59.6 MBytes  500171 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  25.00-26.00  sec  59.6 MBytes  500190 Kbits/sec                  
+[  5][TX-C]  26.00-27.00  sec  59.6 MBytes  499909 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  26.00-27.00  sec  59.6 MBytes  499909 Kbits/sec                  
+[  5][TX-C]  27.00-28.00  sec  59.6 MBytes  500171 Kbits/sec   49    207 KBytes       
+[  7][RX-C]  27.00-28.00  sec  59.6 MBytes  500171 Kbits/sec                  
+[  5][TX-C]  28.00-29.00  sec  59.6 MBytes  499915 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  28.00-29.00  sec  59.6 MBytes  499993 Kbits/sec                  
+[  5][TX-C]  29.00-30.00  sec  59.6 MBytes  499905 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  29.00-30.00  sec  59.6 MBytes  499827 Kbits/sec                  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID][Role] Interval           Transfer     Bitrate         Retr
+[  5][TX-C]   0.00-30.00  sec  1.75 GBytes  499996 Kbits/sec   49             sender
+[  5][TX-C]   0.00-30.00  sec  1.75 GBytes  499992 Kbits/sec                  receiver
+[  7][RX-C]   0.00-30.00  sec  1.75 GBytes  500014 Kbits/sec    0             sender
+[  7][RX-C]   0.00-30.00  sec  1.75 GBytes  499990 Kbits/sec                  receiver
+
+iperf Done.
+END-TS-0 1779563515.261451022

--- a/unit-test/test-data/tcp-bidirectional-server/expected-metrics.json
+++ b/unit-test/test-data/tcp-bidirectional-server/expected-metrics.json
@@ -1,0 +1,6 @@
+{
+  "protocol": "tcp",
+  "bidir": true,
+  "expected_metrics": ["tx-Gbps", "rx-Gbps", "tx-retry/sec"],
+  "description": "TCP bidirectional server - should aggregate tx-Gbps and rx-Gbps from [TX-S] and [RX-S] flows"
+}

--- a/unit-test/test-data/tcp-bidirectional-server/iperf-client-result.txt
+++ b/unit-test/test-data/tcp-bidirectional-server/iperf-client-result.txt
@@ -1,0 +1,80 @@
+BEGIN-TS-0 1779563482.253489588
+Connecting to host 172.30.144.25, port 30002
+[  5] local 10.131.0.84 port 46620 connected to 172.30.144.25 port 30002
+[  7] local 10.131.0.84 port 46632 connected to 172.30.144.25 port 30002
+[ ID][Role] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5][TX-C]   0.00-1.00   sec  59.6 MBytes  499619 Kbits/sec    0    207 KBytes       (omitted)
+[  7][RX-C]   0.00-1.00   sec  59.6 MBytes  499614 Kbits/sec                  (omitted)
+[  5][TX-C]   1.00-2.00   sec  59.6 MBytes  499904 Kbits/sec    0    207 KBytes       (omitted)
+[  7][RX-C]   1.00-2.00   sec  59.6 MBytes  499904 Kbits/sec                  (omitted)
+[  5][TX-C]   2.00-3.00   sec  59.6 MBytes  500175 Kbits/sec    0    207 KBytes       (omitted)
+[  7][RX-C]   2.00-3.00   sec  59.6 MBytes  500253 Kbits/sec                  (omitted)
+[  5][TX-C]   0.00-1.00   sec  59.6 MBytes  499905 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   0.00-1.00   sec  59.6 MBytes  499829 Kbits/sec                  
+[  5][TX-C]   1.00-2.00   sec  59.6 MBytes  500175 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   1.00-2.00   sec  59.6 MBytes  499988 Kbits/sec                  
+[  5][TX-C]   2.00-3.00   sec  59.6 MBytes  499908 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   2.00-3.00   sec  59.6 MBytes  500170 Kbits/sec                  
+[  5][TX-C]   3.00-4.00   sec  59.6 MBytes  499902 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   3.00-4.00   sec  59.6 MBytes  499823 Kbits/sec                  
+[  5][TX-C]   4.00-5.00   sec  59.6 MBytes  500171 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   4.00-5.00   sec  59.6 MBytes  500172 Kbits/sec                  
+[  5][TX-C]   5.00-6.00   sec  59.6 MBytes  499908 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   5.00-6.00   sec  59.6 MBytes  499908 Kbits/sec                  
+[  5][TX-C]   6.00-7.00   sec  59.6 MBytes  499909 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   6.00-7.00   sec  59.6 MBytes  499909 Kbits/sec                  
+[  5][TX-C]   7.00-8.00   sec  59.6 MBytes  500178 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   7.00-8.00   sec  59.6 MBytes  500256 Kbits/sec                  
+[  5][TX-C]   8.00-9.00   sec  59.6 MBytes  499902 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   8.00-9.00   sec  59.6 MBytes  499824 Kbits/sec                  
+[  5][TX-C]   9.00-10.00  sec  59.6 MBytes  499909 Kbits/sec    0    207 KBytes       
+[  7][RX-C]   9.00-10.00  sec  59.6 MBytes  499909 Kbits/sec                  
+[  5][TX-C]  10.00-11.00  sec  59.6 MBytes  500171 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  10.00-11.00  sec  59.6 MBytes  500172 Kbits/sec                  
+[  5][TX-C]  11.00-12.00  sec  59.6 MBytes  499913 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  11.00-12.00  sec  59.6 MBytes  499915 Kbits/sec                  
+[  5][TX-C]  12.00-13.00  sec  59.6 MBytes  499908 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  12.00-13.00  sec  59.6 MBytes  499908 Kbits/sec                  
+[  5][TX-C]  13.00-14.00  sec  59.6 MBytes  500174 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  13.00-14.00  sec  59.6 MBytes  500248 Kbits/sec                  
+[  5][TX-C]  14.00-15.00  sec  59.6 MBytes  499901 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  14.00-15.00  sec  59.6 MBytes  499823 Kbits/sec                  
+[  5][TX-C]  15.00-16.00  sec  59.6 MBytes  499914 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  15.00-16.00  sec  59.6 MBytes  499917 Kbits/sec                  
+[  5][TX-C]  16.00-17.00  sec  59.6 MBytes  500171 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  16.00-17.00  sec  59.6 MBytes  500170 Kbits/sec                  
+[  5][TX-C]  17.00-18.00  sec  59.6 MBytes  499901 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  17.00-18.00  sec  59.6 MBytes  499901 Kbits/sec                  
+[  5][TX-C]  18.00-19.00  sec  59.6 MBytes  499912 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  18.00-19.00  sec  59.6 MBytes  499910 Kbits/sec                  
+[  5][TX-C]  19.00-20.00  sec  59.6 MBytes  500171 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  19.00-20.00  sec  59.6 MBytes  500171 Kbits/sec                  
+[  5][TX-C]  20.00-21.00  sec  59.6 MBytes  499912 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  20.00-21.00  sec  59.6 MBytes  499990 Kbits/sec                  
+[  5][TX-C]  21.00-22.00  sec  59.6 MBytes  499904 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  21.00-22.00  sec  59.6 MBytes  499826 Kbits/sec                  
+[  5][TX-C]  22.00-23.00  sec  59.6 MBytes  500169 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  22.00-23.00  sec  59.6 MBytes  500172 Kbits/sec                  
+[  5][TX-C]  23.00-24.00  sec  59.6 MBytes  499913 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  23.00-24.00  sec  59.6 MBytes  500008 Kbits/sec                  
+[  5][TX-C]  24.00-25.00  sec  59.6 MBytes  499907 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  24.00-25.00  sec  59.6 MBytes  499790 Kbits/sec                  
+[  5][TX-C]  25.00-26.00  sec  59.6 MBytes  500171 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  25.00-26.00  sec  59.6 MBytes  500190 Kbits/sec                  
+[  5][TX-C]  26.00-27.00  sec  59.6 MBytes  499909 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  26.00-27.00  sec  59.6 MBytes  499909 Kbits/sec                  
+[  5][TX-C]  27.00-28.00  sec  59.6 MBytes  500171 Kbits/sec   49    207 KBytes       
+[  7][RX-C]  27.00-28.00  sec  59.6 MBytes  500171 Kbits/sec                  
+[  5][TX-C]  28.00-29.00  sec  59.6 MBytes  499915 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  28.00-29.00  sec  59.6 MBytes  499993 Kbits/sec                  
+[  5][TX-C]  29.00-30.00  sec  59.6 MBytes  499905 Kbits/sec    0    207 KBytes       
+[  7][RX-C]  29.00-30.00  sec  59.6 MBytes  499827 Kbits/sec                  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID][Role] Interval           Transfer     Bitrate         Retr
+[  5][TX-C]   0.00-30.00  sec  1.75 GBytes  499996 Kbits/sec   49             sender
+[  5][TX-C]   0.00-30.00  sec  1.75 GBytes  499992 Kbits/sec                  receiver
+[  7][RX-C]   0.00-30.00  sec  1.75 GBytes  500014 Kbits/sec    0             sender
+[  7][RX-C]   0.00-30.00  sec  1.75 GBytes  499990 Kbits/sec                  receiver
+
+iperf Done.
+END-TS-0 1779563515.261451022

--- a/unit-test/test-data/tcp-bidirectional-server/iperf-server-result.txt
+++ b/unit-test/test-data/tcp-bidirectional-server/iperf-server-result.txt
@@ -1,0 +1,87 @@
+BEGIN-TS-0 1779563438.524179180
+-----------------------------------------------------------
+Server listening on 30002 (test #1)
+-----------------------------------------------------------
+-----------------------------------------------------------
+Server listening on 30002 (test #2)
+-----------------------------------------------------------
+Accepted connection from 10.131.0.84, port 46614
+[  5] local 10.128.2.62 port 30002 connected to 10.131.0.84 port 46620
+[  8] local 10.128.2.62 port 30002 connected to 10.131.0.84 port 46632
+[ ID][Role] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5][RX-S]   0.00-1.00   sec  59.6 MBytes  499618 Kbits/sec                  (omitted)
+[  8][TX-S]   0.00-1.00   sec  59.6 MBytes  499614 Kbits/sec    0    104 KBytes       (omitted)
+[  5][RX-S]   1.00-2.00   sec  59.6 MBytes  499909 Kbits/sec                  (omitted)
+[  8][TX-S]   1.00-2.00   sec  59.6 MBytes  499912 Kbits/sec    0    109 KBytes       (omitted)
+[  5][RX-S]   2.00-3.00   sec  59.6 MBytes  500170 Kbits/sec                  (omitted)
+[  8][TX-S]   2.00-3.00   sec  59.6 MBytes  500170 Kbits/sec    0    109 KBytes       (omitted)
+[  5][RX-S]   0.00-1.00   sec  59.6 MBytes  499901 Kbits/sec                  
+[  8][TX-S]   0.00-1.00   sec  59.6 MBytes  499898 Kbits/sec    0    109 KBytes       
+[  5][RX-S]   1.00-2.00   sec  59.6 MBytes  500175 Kbits/sec                  
+[  8][TX-S]   1.00-2.00   sec  59.6 MBytes  499916 Kbits/sec    0    109 KBytes       
+[  5][RX-S]   2.00-3.00   sec  59.6 MBytes  499909 Kbits/sec                  
+[  8][TX-S]   2.00-3.00   sec  59.6 MBytes  500171 Kbits/sec    0    109 KBytes       
+[  5][RX-S]   3.00-4.00   sec  59.6 MBytes  499908 Kbits/sec                  
+[  8][TX-S]   3.00-4.00   sec  59.6 MBytes  499908 Kbits/sec    0    109 KBytes       
+[  5][RX-S]   4.00-5.00   sec  59.6 MBytes  500171 Kbits/sec                  
+[  8][TX-S]   4.00-5.00   sec  59.6 MBytes  500170 Kbits/sec    0    109 KBytes       
+[  5][RX-S]   5.00-6.00   sec  59.6 MBytes  499909 Kbits/sec                  
+[  8][TX-S]   5.00-6.00   sec  59.6 MBytes  499906 Kbits/sec    0    109 KBytes       
+[  5][RX-S]   6.00-7.00   sec  59.6 MBytes  499909 Kbits/sec                  
+[  8][TX-S]   6.00-7.00   sec  59.6 MBytes  499912 Kbits/sec    0    109 KBytes       
+[  5][RX-S]   7.00-8.00   sec  59.6 MBytes  500170 Kbits/sec                  
+[  8][TX-S]   7.00-8.00   sec  59.6 MBytes  500170 Kbits/sec    0    109 KBytes       
+[  5][RX-S]   8.00-9.00   sec  59.6 MBytes  499909 Kbits/sec                  
+[  8][TX-S]   8.00-9.00   sec  59.6 MBytes  499909 Kbits/sec    0    109 KBytes       
+[  5][RX-S]   9.00-10.00  sec  59.6 MBytes  499909 Kbits/sec                  
+[  8][TX-S]   9.00-10.00  sec  59.6 MBytes  499908 Kbits/sec    0    109 KBytes       
+[  5][RX-S]  10.00-11.00  sec  59.6 MBytes  500171 Kbits/sec                  
+[  8][TX-S]  10.00-11.00  sec  59.6 MBytes  500168 Kbits/sec    0    109 KBytes       
+[  5][RX-S]  11.00-12.00  sec  59.6 MBytes  499904 Kbits/sec                  
+[  8][TX-S]  11.00-12.00  sec  59.6 MBytes  499905 Kbits/sec    0    109 KBytes       
+[  5][RX-S]  12.00-13.00  sec  59.6 MBytes  499909 Kbits/sec                  
+[  8][TX-S]  12.00-13.00  sec  59.6 MBytes  499908 Kbits/sec    0    109 KBytes       
+[  5][RX-S]  13.00-14.00  sec  59.6 MBytes  500175 Kbits/sec                  
+[  8][TX-S]  13.00-14.00  sec  59.6 MBytes  500177 Kbits/sec    0    109 KBytes       
+[  5][RX-S]  14.00-15.00  sec  59.6 MBytes  499909 Kbits/sec                  
+[  8][TX-S]  14.00-15.00  sec  59.6 MBytes  499909 Kbits/sec    0    109 KBytes       
+[  5][RX-S]  15.00-16.00  sec  59.6 MBytes  499904 Kbits/sec                  
+[  8][TX-S]  15.00-16.00  sec  59.6 MBytes  499896 Kbits/sec    0    115 KBytes       
+[  5][RX-S]  16.00-17.00  sec  59.6 MBytes  500171 Kbits/sec                  
+[  8][TX-S]  16.00-17.00  sec  59.6 MBytes  500177 Kbits/sec    0    115 KBytes       
+[  5][RX-S]  17.00-18.00  sec  59.6 MBytes  499913 Kbits/sec                  
+[  8][TX-S]  17.00-18.00  sec  59.6 MBytes  499916 Kbits/sec    0    115 KBytes       
+[  5][RX-S]  18.00-19.00  sec  59.6 MBytes  499908 Kbits/sec                  
+[  8][TX-S]  18.00-19.00  sec  59.6 MBytes  499908 Kbits/sec    0    115 KBytes       
+[  5][RX-S]  19.00-20.00  sec  59.6 MBytes  500171 Kbits/sec                  
+[  8][TX-S]  19.00-20.00  sec  59.6 MBytes  500171 Kbits/sec    0    115 KBytes       
+[  5][RX-S]  20.00-21.00  sec  59.6 MBytes  499909 Kbits/sec                  
+[  8][TX-S]  20.00-21.00  sec  59.6 MBytes  499906 Kbits/sec    0    115 KBytes       
+[  5][RX-S]  21.00-22.00  sec  59.6 MBytes  499908 Kbits/sec                  
+[  8][TX-S]  21.00-22.00  sec  59.6 MBytes  499911 Kbits/sec    0    120 KBytes       
+[  5][RX-S]  22.00-23.00  sec  59.6 MBytes  500171 Kbits/sec                  
+[  8][TX-S]  22.00-23.00  sec  59.6 MBytes  500171 Kbits/sec    0    125 KBytes       
+[  5][RX-S]  23.00-24.00  sec  59.6 MBytes  499909 Kbits/sec                  
+[  8][TX-S]  23.00-24.00  sec  59.6 MBytes  499910 Kbits/sec    0    125 KBytes       
+[  5][RX-S]  24.00-25.00  sec  59.6 MBytes  499904 Kbits/sec                  
+[  8][TX-S]  24.00-25.00  sec  59.6 MBytes  499902 Kbits/sec    0    125 KBytes       
+[  5][RX-S]  25.00-26.00  sec  59.6 MBytes  500173 Kbits/sec                  
+[  8][TX-S]  25.00-26.00  sec  59.6 MBytes  500176 Kbits/sec    0    125 KBytes       
+[  5][RX-S]  26.00-27.00  sec  59.6 MBytes  499906 Kbits/sec                  
+[  8][TX-S]  26.00-27.00  sec  59.6 MBytes  499904 Kbits/sec    0    125 KBytes       
+[  5][RX-S]  27.00-28.00  sec  59.6 MBytes  500171 Kbits/sec                  
+[  8][TX-S]  27.00-28.00  sec  59.6 MBytes  500171 Kbits/sec    0    125 KBytes       
+[  5][RX-S]  28.00-29.00  sec  59.6 MBytes  499913 Kbits/sec                  
+[  8][TX-S]  28.00-29.00  sec  59.6 MBytes  499915 Kbits/sec    0    125 KBytes       
+[  5][RX-S]  29.00-30.00  sec  59.6 MBytes  499904 Kbits/sec                  
+[  8][TX-S]  29.00-30.00  sec  59.6 MBytes  499902 Kbits/sec    0    125 KBytes       
+[  5][RX-S]  30.00-30.00  sec  0.00 Bytes  0.00 Kbits/sec                  
+[  8][TX-S]  30.00-30.00  sec  64.0 KBytes  2404991 Kbits/sec    0    125 KBytes       
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID][Role] Interval           Transfer     Bitrate         Retr
+[  5][RX-S]   0.00-30.00  sec  1.75 GBytes  499992 Kbits/sec                  receiver
+[  8][TX-S]   0.00-30.00  sec  1.75 GBytes  500010 Kbits/sec    0             sender
+-----------------------------------------------------------
+Server listening on 30002 (test #3)
+-----------------------------------------------------------
+END-TS-0 1779563544.141867191

--- a/unit-test/test-data/tcp-hunter-mode/expected-metrics.json
+++ b/unit-test/test-data/tcp-hunter-mode/expected-metrics.json
@@ -1,0 +1,6 @@
+{
+  "protocol": "tcp",
+  "hunter": true,
+  "expected_metrics": ["tx-Gbps", "tx-retry/sec"],
+  "description": "TCP hunter mode - should select highest passing run and generate tx-Gbps"
+}

--- a/unit-test/test-data/tcp-hunter-mode/iperf-client-result.txt
+++ b/unit-test/test-data/tcp-hunter-mode/iperf-client-result.txt
@@ -1,0 +1,176 @@
+HUNTING begin:
+BEGIN-TS-1 1779448715.827976677
+Connecting to host 172.30.219.132, port 30002
+[  5] local 10.131.0.42 port 40609 connected to 172.30.219.132 port 30002
+[ ID] Interval           Transfer     Bitrate         Total Datagrams
+[  5]   0.00-1.00   sec  17.9 MBytes  149866 Kbits/sec  15612  (omitted)
+[  5]   1.00-2.00   sec  17.9 MBytes  150010 Kbits/sec  15626  (omitted)
+[  5]   2.00-3.00   sec  17.9 MBytes  149991 Kbits/sec  15624  (omitted)
+[  5]   0.00-1.00   sec  17.9 MBytes  150026 Kbits/sec  15628  
+[  5]   1.00-2.00   sec  17.9 MBytes  150000 Kbits/sec  15625  
+[  5]   2.00-3.00   sec  17.9 MBytes  149991 Kbits/sec  15624  
+[  5]   3.00-4.00   sec  17.9 MBytes  149992 Kbits/sec  15624  
+[  5]   4.00-5.00   sec  17.9 MBytes  149990 Kbits/sec  15624  
+[  5]   5.00-6.00   sec  17.9 MBytes  149999 Kbits/sec  15625  
+[  5]   6.00-7.00   sec  17.9 MBytes  150000 Kbits/sec  15625  
+[  5]   7.00-8.00   sec  17.9 MBytes  150029 Kbits/sec  15628  
+[  5]   8.00-9.00   sec  17.9 MBytes  149990 Kbits/sec  15624  
+[  5]   9.00-10.00  sec  17.9 MBytes  150009 Kbits/sec  15626  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
+[  5]   0.00-10.00  sec   179 MBytes  150003 Kbits/sec  0.000 ms  0/156253 (0%)  sender
+[  5]   0.00-10.00  sec   179 MBytes  149977 Kbits/sec  0.021 ms  0/156253 (0%)  receiver
+
+iperf Done.
+END-TS-1 1779448728.839584261
+PASS: [  5]   0.00-10.00  sec   179 MBytes  149977 Kbits/sec  0.021 ms  0/156253 (0%)  receiver
+BEGIN-TS-2 1779448728.857562710
+Connecting to host 172.30.219.132, port 30002
+[  5] local 10.131.0.42 port 42260 connected to 172.30.219.132 port 30002
+[ ID] Interval           Transfer     Bitrate         Total Datagrams
+[  5]   0.00-1.00   sec  20.8 MBytes  174853 Kbits/sec  18215  (omitted)
+[  5]   1.00-2.00   sec  20.9 MBytes  174998 Kbits/sec  18229  (omitted)
+[  5]   2.00-3.00   sec  20.9 MBytes  175017 Kbits/sec  18231  (omitted)
+[  5]   0.00-1.00   sec  20.9 MBytes  175005 Kbits/sec  18230  
+[  5]   1.00-2.00   sec  20.9 MBytes  175000 Kbits/sec  18229  
+[  5]   2.00-3.00   sec  20.9 MBytes  174979 Kbits/sec  18227  
+[  5]   3.00-4.00   sec  20.9 MBytes  175017 Kbits/sec  18231  
+[  5]   4.00-5.00   sec  20.9 MBytes  174979 Kbits/sec  18227  
+[  5]   5.00-6.00   sec  20.9 MBytes  175027 Kbits/sec  18232  
+[  5]   6.00-7.00   sec  20.9 MBytes  174970 Kbits/sec  18226  
+[  5]   7.00-8.00   sec  20.9 MBytes  175008 Kbits/sec  18230  
+[  5]   8.00-9.00   sec  20.9 MBytes  175018 Kbits/sec  18231  
+[  5]   9.00-10.00  sec  20.9 MBytes  174997 Kbits/sec  18229  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
+[  5]   0.00-10.00  sec   209 MBytes  175001 Kbits/sec  0.000 ms  0/182292 (0%)  sender
+[  5]   0.00-10.00  sec   209 MBytes  174980 Kbits/sec  0.010 ms  0/182292 (0%)  receiver
+
+iperf Done.
+END-TS-2 1779448741.867853344
+PASS: [  5]   0.00-10.00  sec   209 MBytes  174980 Kbits/sec  0.010 ms  0/182292 (0%)  receiver
+BEGIN-TS-3 1779448741.885925646
+Connecting to host 172.30.219.132, port 30002
+[  5] local 10.131.0.42 port 39330 connected to 172.30.219.132 port 30002
+[ ID] Interval           Transfer     Bitrate         Total Datagrams
+[  5]   0.00-1.00   sec  22.3 MBytes  186881 Kbits/sec  19468  (omitted)
+[  5]   1.00-2.00   sec  22.3 MBytes  186960 Kbits/sec  19475  (omitted)
+[  5]   2.00-3.00   sec  22.3 MBytes  187008 Kbits/sec  19480  (omitted)
+[  5]   0.00-1.00   sec  22.3 MBytes  187007 Kbits/sec  19480  
+[  5]   1.00-2.00   sec  22.3 MBytes  187036 Kbits/sec  19483  
+[  5]   2.00-3.00   sec  22.3 MBytes  186989 Kbits/sec  19478  
+[  5]   3.00-4.00   sec  22.3 MBytes  186989 Kbits/sec  19478  
+[  5]   4.00-5.00   sec  22.3 MBytes  186969 Kbits/sec  19476  
+[  5]   5.00-6.00   sec  22.3 MBytes  186998 Kbits/sec  19479  
+[  5]   6.00-7.00   sec  22.3 MBytes  187018 Kbits/sec  19481  
+[  5]   7.00-8.00   sec  22.3 MBytes  187018 Kbits/sec  19481  
+[  5]   8.00-9.00   sec  22.3 MBytes  186960 Kbits/sec  19475  
+[  5]   9.00-10.00  sec  22.3 MBytes  187026 Kbits/sec  19482  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
+[  5]   0.00-10.00  sec   223 MBytes  187002 Kbits/sec  0.000 ms  0/194793 (0%)  sender
+[  5]   0.00-10.00  sec   223 MBytes  186979 Kbits/sec  0.008 ms  0/194793 (0%)  receiver
+
+iperf Done.
+END-TS-3 1779448754.896023236
+PASS: [  5]   0.00-10.00  sec   223 MBytes  186979 Kbits/sec  0.008 ms  0/194793 (0%)  receiver
+BEGIN-TS-4 1779448754.914326300
+Connecting to host 172.30.219.132, port 30002
+[  5] local 10.131.0.42 port 55560 connected to 172.30.219.132 port 30002
+[ ID] Interval           Transfer     Bitrate         Total Datagrams
+[  5]   0.00-1.00   sec  23.0 MBytes  192832 Kbits/sec  20088  (omitted)
+[  5]   1.00-2.00   sec  23.0 MBytes  192989 Kbits/sec  20103  (omitted)
+[  5]   2.00-3.00   sec  23.0 MBytes  193017 Kbits/sec  20106  (omitted)
+[  5]   0.00-1.00   sec  23.0 MBytes  192998 Kbits/sec  20104  
+[  5]   1.00-2.00   sec  23.0 MBytes  193017 Kbits/sec  20106  
+[  5]   2.00-3.00   sec  23.0 MBytes  192989 Kbits/sec  20103  
+[  5]   3.00-4.00   sec  23.0 MBytes  192989 Kbits/sec  20103  
+[  5]   4.00-5.00   sec  23.0 MBytes  193008 Kbits/sec  20105  
+[  5]   5.00-6.00   sec  23.0 MBytes  192998 Kbits/sec  20104  
+[  5]   6.00-7.00   sec  23.0 MBytes  193008 Kbits/sec  20105  
+[  5]   7.00-8.00   sec  23.0 MBytes  192979 Kbits/sec  20102  
+[  5]   8.00-9.00   sec  23.0 MBytes  193047 Kbits/sec  20109  
+[  5]   9.00-10.00  sec  23.0 MBytes  192959 Kbits/sec  20100  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
+[  5]   0.00-10.00  sec   230 MBytes  193000 Kbits/sec  0.000 ms  0/201041 (0%)  sender
+[  5]   0.00-10.00  sec   230 MBytes  192979 Kbits/sec  0.007 ms  0/201041 (0%)  receiver
+
+iperf Done.
+END-TS-4 1779448767.924095742
+PASS: [  5]   0.00-10.00  sec   230 MBytes  192979 Kbits/sec  0.007 ms  0/201041 (0%)  receiver
+BEGIN-TS-5 1779448767.941561809
+Connecting to host 172.30.219.132, port 30002
+[  5] local 10.131.0.42 port 37959 connected to 172.30.219.132 port 30002
+[ ID] Interval           Transfer     Bitrate         Total Datagrams
+[  5]   0.00-1.00   sec  23.4 MBytes  195877 Kbits/sec  20405  (omitted)
+[  5]   1.00-2.00   sec  23.4 MBytes  195982 Kbits/sec  20415  (omitted)
+[  5]   2.00-3.00   sec  23.4 MBytes  195965 Kbits/sec  20413  (omitted)
+[  5]   0.00-1.00   sec  23.4 MBytes  196012 Kbits/sec  20418  
+[  5]   1.00-2.00   sec  23.4 MBytes  196022 Kbits/sec  20419  
+[  5]   2.00-3.00   sec  23.4 MBytes  196003 Kbits/sec  20417  
+[  5]   3.00-4.00   sec  23.4 MBytes  195975 Kbits/sec  20414  
+[  5]   4.00-5.00   sec  23.4 MBytes  195994 Kbits/sec  20416  
+[  5]   5.00-6.00   sec  23.4 MBytes  196031 Kbits/sec  20420  
+[  5]   6.00-7.00   sec  23.4 MBytes  196013 Kbits/sec  20418  
+[  5]   7.00-8.00   sec  23.4 MBytes  195975 Kbits/sec  20414  
+[  5]   8.00-9.00   sec  23.4 MBytes  195975 Kbits/sec  20414  
+[  5]   9.00-10.00  sec  23.4 MBytes  196021 Kbits/sec  20419  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
+[  5]   0.00-10.00  sec   234 MBytes  196003 Kbits/sec  0.000 ms  0/204169 (0%)  sender
+[  5]   0.00-10.00  sec   234 MBytes  195970 Kbits/sec  0.008 ms  0/204169 (0%)  receiver
+
+iperf Done.
+END-TS-5 1779448780.951773406
+PASS: [  5]   0.00-10.00  sec   234 MBytes  195970 Kbits/sec  0.008 ms  0/204169 (0%)  receiver
+BEGIN-TS-6 1779448780.969608226
+Connecting to host 172.30.219.132, port 30002
+[  5] local 10.131.0.42 port 51771 connected to 172.30.219.132 port 30002
+[ ID] Interval           Transfer     Bitrate         Total Datagrams
+[  5]   0.00-1.00   sec  23.6 MBytes  197826 Kbits/sec  20608  (omitted)
+[  5]   1.00-2.00   sec  23.6 MBytes  198007 Kbits/sec  20626  (omitted)
+[  5]   2.00-3.00   sec  23.6 MBytes  197991 Kbits/sec  20624  (omitted)
+[  5]   0.00-1.00   sec  23.6 MBytes  197999 Kbits/sec  20625  
+[  5]   1.00-2.00   sec  23.6 MBytes  198039 Kbits/sec  20629  
+[  5]   2.00-3.00   sec  23.6 MBytes  198000 Kbits/sec  20625  
+[  5]   3.00-4.00   sec  23.6 MBytes  197971 Kbits/sec  20622  
+[  5]   4.00-5.00   sec  23.6 MBytes  198010 Kbits/sec  20626  
+[  5]   5.00-6.00   sec  23.6 MBytes  198010 Kbits/sec  20626  
+[  5]   6.00-7.00   sec  23.6 MBytes  198009 Kbits/sec  20626  
+[  5]   7.00-8.00   sec  23.6 MBytes  197991 Kbits/sec  20624  
+[  5]   8.00-9.00   sec  23.6 MBytes  198009 Kbits/sec  20626  
+[  5]   9.00-10.00  sec  23.6 MBytes  197979 Kbits/sec  20623  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
+[  5]   0.00-10.00  sec   236 MBytes  198002 Kbits/sec  0.000 ms  0/206252 (0%)  sender
+[  5]   0.00-10.00  sec   236 MBytes  197978 Kbits/sec  0.007 ms  0/206252 (0%)  receiver
+
+iperf Done.
+END-TS-6 1779448793.978326181
+PASS: [  5]   0.00-10.00  sec   236 MBytes  197978 Kbits/sec  0.007 ms  0/206252 (0%)  receiver
+BEGIN-TS-7 1779448793.995506919
+Connecting to host 172.30.219.132, port 30002
+[  5] local 10.131.0.42 port 59558 connected to 172.30.219.132 port 30002
+[ ID] Interval           Transfer     Bitrate         Total Datagrams
+[  5]   0.00-1.00   sec  23.7 MBytes  198881 Kbits/sec  20718  (omitted)
+[  5]   1.00-2.00   sec  23.7 MBytes  198978 Kbits/sec  20727  (omitted)
+[  5]   2.00-3.00   sec  23.7 MBytes  199008 Kbits/sec  20730  (omitted)
+[  5]   0.00-1.00   sec  23.7 MBytes  198959 Kbits/sec  20725  
+[  5]   1.00-2.00   sec  23.7 MBytes  199008 Kbits/sec  20730  
+[  5]   2.00-3.00   sec  23.7 MBytes  198998 Kbits/sec  20729  
+[  5]   3.00-4.00   sec  23.7 MBytes  198999 Kbits/sec  20729  
+[  5]   4.00-5.00   sec  23.7 MBytes  198998 Kbits/sec  20729  
+[  5]   5.00-6.00   sec  23.7 MBytes  198998 Kbits/sec  20729  
+[  5]   6.00-7.00   sec  23.7 MBytes  199008 Kbits/sec  20730  
+[  5]   7.00-8.00   sec  23.7 MBytes  199032 Kbits/sec  20733  
+[  5]   8.00-9.00   sec  23.7 MBytes  198993 Kbits/sec  20728  
+[  5]   9.00-10.00  sec  23.7 MBytes  199001 Kbits/sec  20729  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
+[  5]   0.00-10.00  sec   237 MBytes  199000 Kbits/sec  0.000 ms  0/207291 (0%)  sender
+[  5]   0.00-10.00  sec   237 MBytes  198987 Kbits/sec  0.009 ms  0/207291 (0%)  receiver
+
+iperf Done.
+END-TS-7 1779448807.005491249
+PASS: [  5]   0.00-10.00  sec   237 MBytes  198987 Kbits/sec  0.009 ms  0/207291 (0%)  receiver

--- a/unit-test/test-data/tcp-unidirectional-client/expected-metrics.json
+++ b/unit-test/test-data/tcp-unidirectional-client/expected-metrics.json
@@ -1,0 +1,5 @@
+{
+  "protocol": "tcp",
+  "expected_metrics": ["tx-Gbps", "tx-retry/sec"],
+  "description": "TCP sender - should generate tx-Gbps and tx-retry/sec"
+}

--- a/unit-test/test-data/tcp-unidirectional-client/iperf-client-result.txt
+++ b/unit-test/test-data/tcp-unidirectional-client/iperf-client-result.txt
@@ -1,0 +1,41 @@
+BEGIN-TS-0 1779554823.073021327
+Connecting to host 172.30.39.93, port 30002
+[  5] local 10.131.0.80 port 53526 connected to 172.30.39.93 port 30002
+[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5]   0.00-1.00   sec   560 MBytes  4696000 Kbits/sec   64    924 KBytes       
+[  5]   1.00-2.00   sec   537 MBytes  4506472 Kbits/sec    0    968 KBytes       
+[  5]   2.00-3.00   sec   537 MBytes  4503413 Kbits/sec    0    982 KBytes       
+[  5]   3.00-4.00   sec   539 MBytes  4522061 Kbits/sec    0    986 KBytes       
+[  5]   4.00-5.00   sec   537 MBytes  4503566 Kbits/sec    0   1000 KBytes       
+[  5]   5.00-6.00   sec   537 MBytes  4506296 Kbits/sec    0   1004 KBytes       
+[  5]   6.00-7.00   sec   537 MBytes  4501012 Kbits/sec    0   1012 KBytes       
+[  5]   7.00-8.00   sec   537 MBytes  4506436 Kbits/sec   47   1012 KBytes       
+[  5]   8.00-9.00   sec   536 MBytes  4498207 Kbits/sec   34   1014 KBytes       
+[  5]   9.00-10.00  sec   537 MBytes  4503585 Kbits/sec    0   1015 KBytes       
+[  5]  10.00-11.00  sec   530 MBytes  4443381 Kbits/sec   20    454 KBytes       
+[  5]  11.00-12.00  sec   537 MBytes  4506264 Kbits/sec    0    962 KBytes       
+[  5]  12.00-13.00  sec   537 MBytes  4506080 Kbits/sec    0   1004 KBytes       
+[  5]  13.00-14.00  sec   537 MBytes  4503809 Kbits/sec    0   1012 KBytes       
+[  5]  14.00-15.00  sec   537 MBytes  4506188 Kbits/sec    0   1015 KBytes       
+[  5]  15.00-16.00  sec   537 MBytes  4503697 Kbits/sec    0   1015 KBytes       
+[  5]  16.00-17.00  sec   537 MBytes  4503589 Kbits/sec    0   1015 KBytes       
+[  5]  17.00-18.00  sec   537 MBytes  4506224 Kbits/sec    0   1019 KBytes       
+[  5]  18.00-19.00  sec   537 MBytes  4506332 Kbits/sec    0   1019 KBytes       
+[  5]  19.00-20.00  sec   537 MBytes  4505832 Kbits/sec    0   1019 KBytes       
+[  5]  20.00-21.00  sec   537 MBytes  4504062 Kbits/sec    0   1019 KBytes       
+[  5]  21.00-22.00  sec   535 MBytes  4487905 Kbits/sec   42    362 KBytes       
+[  5]  22.00-23.00  sec   537 MBytes  4506255 Kbits/sec    0    921 KBytes       
+[  5]  23.00-24.00  sec   537 MBytes  4506152 Kbits/sec    0    965 KBytes       
+[  5]  24.00-25.00  sec   537 MBytes  4501121 Kbits/sec  186    794 KBytes       
+[  5]  25.00-26.00  sec   537 MBytes  4506251 Kbits/sec    0    969 KBytes       
+[  5]  26.00-27.00  sec   537 MBytes  4503594 Kbits/sec    0    974 KBytes       
+[  5]  27.00-28.00  sec   537 MBytes  4506057 Kbits/sec   40    986 KBytes       
+[  5]  28.00-29.00  sec   537 MBytes  4503868 Kbits/sec    0    995 KBytes       
+[  5]  29.00-30.00  sec   538 MBytes  4508669 Kbits/sec    0   1000 KBytes       
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Retr
+[  5]   0.00-30.00  sec  15.7 GBytes  4509080 Kbits/sec  433             sender
+[  5]   0.00-30.00  sec  15.7 GBytes  4508477 Kbits/sec                  receiver
+
+iperf Done.
+END-TS-0 1779554853.080880881

--- a/unit-test/test-data/tcp-unidirectional-server/description.txt
+++ b/unit-test/test-data/tcp-unidirectional-server/description.txt
@@ -1,0 +1,4 @@
+TCP unidirectional server (receiver)
+Header: [ ID] Interval Transfer Bitrate
+No special columns (no Retr, no Lost/Total, no Datagrams)
+Should be detected as TCP receiver and generate rx-Gbps metrics

--- a/unit-test/test-data/tcp-unidirectional-server/expected-metrics.json
+++ b/unit-test/test-data/tcp-unidirectional-server/expected-metrics.json
@@ -1,0 +1,5 @@
+{
+  "protocol": "tcp",
+  "expected_metrics": ["rx-Gbps"],
+  "description": "TCP receiver - should generate rx-Gbps only"
+}

--- a/unit-test/test-data/tcp-unidirectional-server/iperf-client-result.txt
+++ b/unit-test/test-data/tcp-unidirectional-server/iperf-client-result.txt
@@ -1,0 +1,41 @@
+BEGIN-TS-0 1779554823.073021327
+Connecting to host 172.30.39.93, port 30002
+[  5] local 10.131.0.80 port 53526 connected to 172.30.39.93 port 30002
+[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5]   0.00-1.00   sec   560 MBytes  4696000 Kbits/sec   64    924 KBytes       
+[  5]   1.00-2.00   sec   537 MBytes  4506472 Kbits/sec    0    968 KBytes       
+[  5]   2.00-3.00   sec   537 MBytes  4503413 Kbits/sec    0    982 KBytes       
+[  5]   3.00-4.00   sec   539 MBytes  4522061 Kbits/sec    0    986 KBytes       
+[  5]   4.00-5.00   sec   537 MBytes  4503566 Kbits/sec    0   1000 KBytes       
+[  5]   5.00-6.00   sec   537 MBytes  4506296 Kbits/sec    0   1004 KBytes       
+[  5]   6.00-7.00   sec   537 MBytes  4501012 Kbits/sec    0   1012 KBytes       
+[  5]   7.00-8.00   sec   537 MBytes  4506436 Kbits/sec   47   1012 KBytes       
+[  5]   8.00-9.00   sec   536 MBytes  4498207 Kbits/sec   34   1014 KBytes       
+[  5]   9.00-10.00  sec   537 MBytes  4503585 Kbits/sec    0   1015 KBytes       
+[  5]  10.00-11.00  sec   530 MBytes  4443381 Kbits/sec   20    454 KBytes       
+[  5]  11.00-12.00  sec   537 MBytes  4506264 Kbits/sec    0    962 KBytes       
+[  5]  12.00-13.00  sec   537 MBytes  4506080 Kbits/sec    0   1004 KBytes       
+[  5]  13.00-14.00  sec   537 MBytes  4503809 Kbits/sec    0   1012 KBytes       
+[  5]  14.00-15.00  sec   537 MBytes  4506188 Kbits/sec    0   1015 KBytes       
+[  5]  15.00-16.00  sec   537 MBytes  4503697 Kbits/sec    0   1015 KBytes       
+[  5]  16.00-17.00  sec   537 MBytes  4503589 Kbits/sec    0   1015 KBytes       
+[  5]  17.00-18.00  sec   537 MBytes  4506224 Kbits/sec    0   1019 KBytes       
+[  5]  18.00-19.00  sec   537 MBytes  4506332 Kbits/sec    0   1019 KBytes       
+[  5]  19.00-20.00  sec   537 MBytes  4505832 Kbits/sec    0   1019 KBytes       
+[  5]  20.00-21.00  sec   537 MBytes  4504062 Kbits/sec    0   1019 KBytes       
+[  5]  21.00-22.00  sec   535 MBytes  4487905 Kbits/sec   42    362 KBytes       
+[  5]  22.00-23.00  sec   537 MBytes  4506255 Kbits/sec    0    921 KBytes       
+[  5]  23.00-24.00  sec   537 MBytes  4506152 Kbits/sec    0    965 KBytes       
+[  5]  24.00-25.00  sec   537 MBytes  4501121 Kbits/sec  186    794 KBytes       
+[  5]  25.00-26.00  sec   537 MBytes  4506251 Kbits/sec    0    969 KBytes       
+[  5]  26.00-27.00  sec   537 MBytes  4503594 Kbits/sec    0    974 KBytes       
+[  5]  27.00-28.00  sec   537 MBytes  4506057 Kbits/sec   40    986 KBytes       
+[  5]  28.00-29.00  sec   537 MBytes  4503868 Kbits/sec    0    995 KBytes       
+[  5]  29.00-30.00  sec   538 MBytes  4508669 Kbits/sec    0   1000 KBytes       
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Retr
+[  5]   0.00-30.00  sec  15.7 GBytes  4509080 Kbits/sec  433             sender
+[  5]   0.00-30.00  sec  15.7 GBytes  4508477 Kbits/sec                  receiver
+
+iperf Done.
+END-TS-0 1779554853.080880881

--- a/unit-test/test-data/tcp-unidirectional-server/iperf-server-result.txt
+++ b/unit-test/test-data/tcp-unidirectional-server/iperf-server-result.txt
@@ -1,0 +1,48 @@
+BEGIN-TS-0 1779554780.163774594
+-----------------------------------------------------------
+Server listening on 30002 (test #1)
+-----------------------------------------------------------
+-----------------------------------------------------------
+Server listening on 30002 (test #2)
+-----------------------------------------------------------
+Accepted connection from 10.131.0.80, port 53522
+[  5] local 10.128.2.58 port 30002 connected to 10.131.0.80 port 53526
+[ ID] Interval           Transfer     Bitrate
+[  5]   0.00-1.00   sec   558 MBytes  4676843 Kbits/sec                  
+[  5]   1.00-2.00   sec   537 MBytes  4504919 Kbits/sec                  
+[  5]   2.00-3.00   sec   537 MBytes  4504719 Kbits/sec                  
+[  5]   3.00-4.00   sec   539 MBytes  4520871 Kbits/sec                  
+[  5]   4.00-5.00   sec   537 MBytes  4504776 Kbits/sec                  
+[  5]   5.00-6.00   sec   537 MBytes  4505190 Kbits/sec                  
+[  5]   6.00-7.00   sec   537 MBytes  4502472 Kbits/sec                  
+[  5]   7.00-8.00   sec   537 MBytes  4504336 Kbits/sec                  
+[  5]   8.00-9.00   sec   536 MBytes  4498444 Kbits/sec                  
+[  5]   9.00-10.00  sec   537 MBytes  4505191 Kbits/sec                  
+[  5]  10.00-11.00  sec   530 MBytes  4443099 Kbits/sec                  
+[  5]  11.00-12.00  sec   537 MBytes  4505228 Kbits/sec                  
+[  5]  12.00-13.00  sec   537 MBytes  4505070 Kbits/sec                  
+[  5]  13.00-14.00  sec   537 MBytes  4504838 Kbits/sec                  
+[  5]  14.00-15.00  sec   537 MBytes  4505578 Kbits/sec                  
+[  5]  15.00-16.00  sec   537 MBytes  4505276 Kbits/sec                  
+[  5]  16.00-17.00  sec   537 MBytes  4503480 Kbits/sec                  
+[  5]  17.00-18.00  sec   537 MBytes  4506972 Kbits/sec                  
+[  5]  18.00-19.00  sec   537 MBytes  4504913 Kbits/sec                  
+[  5]  19.00-20.00  sec   537 MBytes  4505127 Kbits/sec                  
+[  5]  20.00-21.00  sec   537 MBytes  4505095 Kbits/sec                  
+[  5]  21.00-22.00  sec   535 MBytes  4488643 Kbits/sec                  
+[  5]  22.00-23.00  sec   537 MBytes  4505079 Kbits/sec                  
+[  5]  23.00-24.00  sec   537 MBytes  4505305 Kbits/sec                  
+[  5]  24.00-25.00  sec   537 MBytes  4502825 Kbits/sec                  
+[  5]  25.00-26.00  sec   537 MBytes  4505228 Kbits/sec                  
+[  5]  26.00-27.00  sec   537 MBytes  4504972 Kbits/sec                  
+[  5]  27.00-28.00  sec   537 MBytes  4503950 Kbits/sec                  
+[  5]  28.00-29.00  sec   537 MBytes  4504857 Kbits/sec                  
+[  5]  29.00-30.00  sec   538 MBytes  4509382 Kbits/sec                  
+[  5]  30.00-30.00  sec   519 KBytes  7287986 Kbits/sec                  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate
+[  5]   0.00-30.00  sec  15.7 GBytes  4508477 Kbits/sec                  receiver
+-----------------------------------------------------------
+Server listening on 30002 (test #3)
+-----------------------------------------------------------
+END-TS-0 1779554880.214833184

--- a/unit-test/test-data/udp-receiver/expected-metrics.json
+++ b/unit-test/test-data/udp-receiver/expected-metrics.json
@@ -1,0 +1,5 @@
+{
+  "protocol": "udp",
+  "expected_metrics": ["rx-Gbps", "rx-lost/sec", "rx-pps"],
+  "description": "UDP receiver - should generate rx-Gbps, rx-lost/sec, and rx-pps"
+}

--- a/unit-test/test-data/udp-receiver/iperf-client-result.txt
+++ b/unit-test/test-data/udp-receiver/iperf-client-result.txt
@@ -1,0 +1,24 @@
+BEGIN-TS-0 1779410321.165499056
+Connecting to host 172.30.122.114, port 30002
+[  5] local 10.131.0.22 port 36410 connected to 172.30.122.114 port 30002
+[ ID] Interval           Transfer     Bitrate         Total Datagrams
+[  5]   0.00-1.00   sec   119 MBytes  999007 Kbits/sec  104070  (omitted)
+[  5]   1.00-2.00   sec   119 MBytes  1000128 Kbits/sec  104180  (omitted)
+[  5]   2.00-3.00   sec   119 MBytes  1000395 Kbits/sec  104205  (omitted)
+[  5]   0.00-1.00   sec   119 MBytes  1000333 Kbits/sec  104207  
+[  5]   1.00-2.00   sec   119 MBytes  999715 Kbits/sec  104133  
+[  5]   2.00-3.00   sec   119 MBytes  1000058 Kbits/sec  104171  
+[  5]   3.00-4.00   sec   119 MBytes  999848 Kbits/sec  104157  
+[  5]   4.00-5.00   sec   119 MBytes  999682 Kbits/sec  104131  
+[  5]   5.00-6.00   sec   119 MBytes  1000448 Kbits/sec  104210  
+[  5]   6.00-7.00   sec   119 MBytes  999529 Kbits/sec  104121  
+[  5]   7.00-8.00   sec   119 MBytes  1000218 Kbits/sec  104186  
+[  5]   8.00-9.00   sec   119 MBytes  1000444 Kbits/sec  104215  
+[  5]   9.00-10.00  sec   119 MBytes  999345 Kbits/sec  104100  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
+[  5]   0.00-10.00  sec  1.16 GBytes  999963 Kbits/sec  0.000 ms  0/1041631 (0%)  sender
+[  5]   0.00-10.00  sec  1.16 GBytes  999100 Kbits/sec  0.003 ms  1284/1041631 (0.12%)  receiver
+
+iperf Done.
+END-TS-0 1779410334.175392316

--- a/unit-test/test-data/udp-receiver/iperf-server-result.txt
+++ b/unit-test/test-data/udp-receiver/iperf-server-result.txt
@@ -1,0 +1,31 @@
+BEGIN-TS-0 1779410281.418629755
+-----------------------------------------------------------
+Server listening on 30002 (test #1)
+-----------------------------------------------------------
+-----------------------------------------------------------
+Server listening on 30002 (test #2)
+-----------------------------------------------------------
+Accepted connection from 10.131.0.22, port 38120
+[  5] local 10.128.2.22 port 30002 connected to 10.131.0.22 port 36410
+[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
+[  5]   0.00-1.00   sec   119 MBytes  996289 Kbits/sec  0.003 ms  276/104057 (0.27%)  (omitted)
+[  5]   1.00-2.00   sec   119 MBytes  998905 Kbits/sec  0.006 ms  124/104176 (0.12%)  (omitted)
+[  5]   2.00-3.00   sec   119 MBytes  998952 Kbits/sec  0.019 ms  17/104081 (0.016%)  (omitted)
+[  5]   0.00-1.00   sec   119 MBytes  999189 Kbits/sec  0.002 ms  114/104208 (0.11%)  
+[  5]   1.00-2.00   sec   119 MBytes  999101 Kbits/sec  0.014 ms  65/104132 (0.062%)  
+[  5]   2.00-3.00   sec   119 MBytes  999255 Kbits/sec  0.014 ms  81/104171 (0.078%)  
+[  5]   3.00-4.00   sec   119 MBytes  999908 Kbits/sec  0.004 ms  0/104157 (0%)  
+[  5]   4.00-5.00   sec   119 MBytes  1000809 Kbits/sec  0.008 ms  3/104253 (0.0029%)  
+[  5]   5.00-6.00   sec   119 MBytes  994878 Kbits/sec  0.002 ms  484/104118 (0.46%)  
+[  5]   6.00-7.00   sec   119 MBytes  1000610 Kbits/sec  0.006 ms  0/104224 (0%)  
+[  5]   7.00-8.00   sec   119 MBytes  998241 Kbits/sec  0.003 ms  67/104057 (0.064%)  
+[  5]   8.00-9.00   sec   119 MBytes  1000669 Kbits/sec  0.005 ms  0/104235 (0%)  
+[  5]   9.00-10.00  sec   119 MBytes  999877 Kbits/sec  0.006 ms  53/104202 (0.051%)  
+[  5]  10.00-10.00  sec  17.6 KBytes  83818 Kbits/sec  0.003 ms  0/15 (0%)  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
+[  5]   0.00-10.00  sec  1.16 GBytes  999100 Kbits/sec  0.003 ms  867/1041772 (0.083%)  receiver
+-----------------------------------------------------------
+Server listening on 30002 (test #3)
+-----------------------------------------------------------
+END-TS-0 1779410361.003785439

--- a/unit-test/test-data/udp-sender/expected-metrics.json
+++ b/unit-test/test-data/udp-sender/expected-metrics.json
@@ -1,0 +1,5 @@
+{
+  "protocol": "udp",
+  "expected_metrics": ["tx-Gbps"],
+  "description": "UDP sender - should generate tx-Gbps only"
+}

--- a/unit-test/test-data/udp-sender/iperf-client-result.txt
+++ b/unit-test/test-data/udp-sender/iperf-client-result.txt
@@ -1,0 +1,24 @@
+BEGIN-TS-0 1779410321.165499056
+Connecting to host 172.30.122.114, port 30002
+[  5] local 10.131.0.22 port 36410 connected to 172.30.122.114 port 30002
+[ ID] Interval           Transfer     Bitrate         Total Datagrams
+[  5]   0.00-1.00   sec   119 MBytes  999007 Kbits/sec  104070  (omitted)
+[  5]   1.00-2.00   sec   119 MBytes  1000128 Kbits/sec  104180  (omitted)
+[  5]   2.00-3.00   sec   119 MBytes  1000395 Kbits/sec  104205  (omitted)
+[  5]   0.00-1.00   sec   119 MBytes  1000333 Kbits/sec  104207  
+[  5]   1.00-2.00   sec   119 MBytes  999715 Kbits/sec  104133  
+[  5]   2.00-3.00   sec   119 MBytes  1000058 Kbits/sec  104171  
+[  5]   3.00-4.00   sec   119 MBytes  999848 Kbits/sec  104157  
+[  5]   4.00-5.00   sec   119 MBytes  999682 Kbits/sec  104131  
+[  5]   5.00-6.00   sec   119 MBytes  1000448 Kbits/sec  104210  
+[  5]   6.00-7.00   sec   119 MBytes  999529 Kbits/sec  104121  
+[  5]   7.00-8.00   sec   119 MBytes  1000218 Kbits/sec  104186  
+[  5]   8.00-9.00   sec   119 MBytes  1000444 Kbits/sec  104215  
+[  5]   9.00-10.00  sec   119 MBytes  999345 Kbits/sec  104100  
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Jitter    Lost/Total Datagrams
+[  5]   0.00-10.00  sec  1.16 GBytes  999963 Kbits/sec  0.000 ms  0/1041631 (0%)  sender
+[  5]   0.00-10.00  sec  1.16 GBytes  999100 Kbits/sec  0.003 ms  1284/1041631 (0.12%)  receiver
+
+iperf Done.
+END-TS-0 1779410334.175392316


### PR DESCRIPTION
1. Add --bidir mode
2. Add multi iperf engines per pod that distribute IRQ pinning among sibbling engines.
3. Implement separate client/server postprocess to handle --bidir.
4. Add comprehensive docs
5. Add unit-test for postproces as it now handles a variety output formats.

Implementations:
------------------------

1. For bidir support, use passthru to pass the extra argument "--bidir" to client and server and postprocess. The main code change is in postprocess support since we now process client and server. outputs.
3. For multi-engine per pod, the main code change is the irq pinning logic. Each client uses the same algorithm to derive its IRQ assigment and pins them to its CPU.

Major File Changes:
------------------

1. iperf-post-process.py (rewrite)  - has the most signisficant changes. We have switched from the previous scheme of processing the client iperf output only (the client has "-get-server-output") to now processing client and server outputs individually. With --bidir, parsing the mixed client and server outputs as in the old scheme is un-managegeable.
2. iperf-pin (new) - contains the IRQ pinning. Each engine knows its index. Using the same algorithm they derive theirs IRQ assigment.

Unit test
------------

1. Ran all 8 test cases including the exsiting TCP/UDP unidirection, hunter (binary search) tests, and the new "--bidir" and multi-engine tests.
2. Use those 8 test cases as sample data for unit-test.