### PR TITLE
feat: write post-process-data.json to postprocess/ directory

### DIFF
--- a/iperf-post-process.py
+++ b/iperf-post-process.py
@@ -547,7 +547,7 @@ def process_proto(data_file, times, names, omit, metrics):
         ],
     }
 
-    with open("post-process-data.json", "w") as f:
+    with open("postprocess/post-process-data.json", "w") as f:
         json.dump(sample_data, f)
 
     return primary_metric

--- a/unit-test/run-tests.py
+++ b/unit-test/run-tests.py
@@ -44,10 +44,12 @@ def run_test_case(test_dir):
 
     # Copy test files to the real script directory (where wrapper will run)
     # Clean up any previous test artifacts first
-    for artifact in ["iperf-client-result.txt", "iperf-server-result.txt",
-                     "metric-data-*.json", "metric-data-*.csv*", "post-process-data.json"]:
+    for artifact in ["iperf-client-result.txt", "iperf-server-result.txt"]:
         for f in REAL_SCRIPT_DIR.glob(artifact):
             f.unlink()
+    pp_dir = REAL_SCRIPT_DIR / "postprocess"
+    if pp_dir.exists():
+        shutil.rmtree(pp_dir)
 
     # Copy input files to real script directory
     if (test_dir / "iperf-client-result.txt").exists():
@@ -120,14 +122,13 @@ def run_test_case(test_dir):
 
     finally:
         # Clean up test files from real script directory
-        for artifact in ["iperf-client-result.txt", "iperf-server-result.txt",
-                         "post-process-data.json"]:
+        for artifact in ["iperf-client-result.txt", "iperf-server-result.txt"]:
             artifact_path = REAL_SCRIPT_DIR / artifact
             if artifact_path.exists():
                 artifact_path.unlink()
-        for pattern in ["metric-data-*.json", "metric-data-*.csv*"]:
-            for f in REAL_SCRIPT_DIR.glob(pattern):
-                f.unlink()
+        pp_dir = REAL_SCRIPT_DIR / "postprocess"
+        if pp_dir.exists():
+            shutil.rmtree(pp_dir)
 
 def main():
     """Run all tests"""


### PR DESCRIPTION
## Summary
- Write post-process-data.json to the postprocess/ subdirectory instead of the sample root directory
- Part of the Phase 2 migration for PERFNFV-316 (dedicated postprocess/ directory for all post-processing artifacts)

## Jira
[PERFNFV-316](https://redhat.atlassian.net/browse/PERFNFV-316)

## Depends on
- toolbox PR #117 (merged) — CDMMetrics output_dir
- rickshaw PR #826 (merged) — orchestration creates/cleans postprocess/

🤖 Generated with [Claude Code](https://claude.com/claude-code)