### PR TITLE
feat: simplify service discovery using engine infrastructure

### DIFF
--- a/iperf-client
+++ b/iperf-client
@@ -152,18 +152,12 @@ uname -a
 # Unless the user specifies a specific remotehost argument, this must
 # be sourced from the endpoint (which gets it from the client)
 if [ -z "$remotehost" ]; then
-    echo "--remotehost was not set via cmdline args, checking any messages from the endpoint"
+    echo "--remotehost was not set via cmdline args, checking for resolved service info"
     echo "These files exist in ./msgs/rx:"
     /bin/ls -l msgs/rx
-    file="msgs/rx/endpoint-start-end:1"  
-    if [ ! -e "${file}" ]; then
-        # File exists when EP created SVC to frontend server.
-        # EP does not create SVC when hostNetwork or remotehost server
-        #  in which cases server IP is in server-start-end:1
-        file="msgs/rx/server-start-end:1"
-    fi
+    file="msgs/rx/svc"
     if [ -e "$file" ]; then
-        echo "Found $file"
+        echo "Found resolved service info: ${file}"
         ipaddr=`jq -r '.svc.ip' $file`
         if [ ! -z "$ipaddr" ]; then
             echo "Found server IP $ipaddr"

--- a/iperf-server-start
+++ b/iperf-server-start
@@ -199,8 +199,8 @@ else
     echo "Not going to look for an IP since --ifname was not used."
 fi
 
-# Queue ip/port info, to be sent to endpoint
-echo '{"recipient":{"type":"all","id":"all"},"user-object":{"svc":{"ip":"'$ip'","ports":['$control_port,$data_port']}}}' >msgs/tx/svc
+# Queue service info for the engine infrastructure to deliver
+echo '{"svc":{"ip":"'$ip'","ports":['$control_port,$data_port']}}' >msgs/tx/svc
 
 echo "Existing listening ports:"
 ss -tlnp


### PR DESCRIPTION
## Summary
- Server writes raw JSON payload to `msgs/tx/svc` — no roadblock addressing
- Client reads resolved service info from `msgs/rx/svc` — no multi-file fallback chain
- Engine infrastructure (rickshaw PR #832) handles message addressing, targeting, and resolution

## Test plan
- [ ] Run single-pair iperf on remotehosts — verify `msgs/rx/svc` exists with correct IP/ports
- [ ] Run on kube — verify `msgs/rx/svc` has Service IP (not pod IP)
- [ ] Verify benchmark completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)