### PR TITLE
fix: make --protocol handler reachable and correct error detection

### DIFF
--- a/iperf-base
+++ b/iperf-base
@@ -7,7 +7,7 @@ if ! source ${TOOLBOX_HOME}/bash/library/bench-base; then echo "ERROR: Could not
 # For PIN functionality, we want same NUMA and separate CPU for client and server.
 # The caller provides the CPU list of its chosen NUMA.
 #
-# Argument: <role> i.e cient or server
+# Argument: <role> i.e client or server
 # Argument: <cpu_list>, a comma separated cpu list
 # Return: 
 #  1. Do nothing if cpu list contains less than 2 CPUs.

--- a/iperf-client
+++ b/iperf-client
@@ -78,7 +78,7 @@ while true; do
         --max-loss-pct)
             shift;
             max_loss_pct=$1
-            echo "max-loss-pct=$max-loss-pct"
+            echo "max-loss-pct=$max_loss_pct"
             shift
             ;;
         --remotehost)

--- a/iperf-hunter
+++ b/iperf-hunter
@@ -115,7 +115,7 @@ function iperf-drop-analyzer {
     receiver_line=$(perl -e 'print reverse <>' $rfile | grep -m 1 "receiver")
     debug_pr receiver_line=$line
 
-    #colum 11 is Lost/Total
+    #column 11 is Lost/Total
     __tuple="$(echo $receiver_line | awk '{print $11}')"
     Lost=$(echo $__tuple | awk -F'/' '{print $1}')
     Total=$(echo $__tuple | awk -F'/' '{print $2}')

--- a/iperf-server-start
+++ b/iperf-server-start
@@ -46,7 +46,7 @@ while true; do
             echo "ifname=$ifname"
             shift
             ;;
-        --protocol|--length|--remotehost|--time|--bitrate)
+        --length|--remotehost|--time|--bitrate)
             shift;
             shift;
             ;;
@@ -173,7 +173,7 @@ if [ ! -z "$ifname" ]; then
         elif [ "$ipv" == "6" ]; then
             echo "$ifname matches index $ifname_idx, looking for ipv6 (inet6) in addr_info:"
             jq '.['$ifname_idx'].addr_info' ip.json
-            # Find the first ipv4 address
+            # Find the first ipv6 address
             addr_idx=`jq '.['$ifname_idx'].addr_info | to_entries | .[] | if (.value.family == "inet6") then .key else null end' ip.json | grep -v null | head -1`
             if [ ! -z $addr_idx ]; then
                 echo "Found inet in index $addr_idx:"
@@ -267,7 +267,7 @@ echo $pid >iperf-server.pid
 # Wait a little bit to see if the server errored out
 sleep 10
 if grep -q -i error iperf-server-result.txt; then
-    exit_error "Server failed to start: `grep -i error iperf-server-results.txt`"
+    exit_error "Server failed to start: `grep -i error iperf-server-result.txt`"
 fi
 echo ps:
 ps aux | grep iperf3


### PR DESCRIPTION
## Summary

- **--protocol unreachable**: `--protocol` was listed in the discard pattern on line 49 alongside `--length`, `--remotehost`, `--time`, and `--bitrate`. Since case matches the first pattern, the real `--protocol` handler that sets `protocol="--udp"` on line 65 was never reached — the server never ran in UDP mode
- **Wrong filename in error message**: line 270 grepped `iperf-server-results.txt` (plural) but the actual file is `iperf-server-result.txt` (singular) — error details were always empty when a server startup failure was detected
- **$max-loss-pct**: hyphens interpreted as subtraction in bash — the debug echo showed an empty value instead of the actual max_loss_pct
- **Comment typos**: cient → client, colum → column, ipv4 → ipv6 in the ipv6 code block

Fixes https://github.com/perftool-incubator/bench-iperf/issues/53

## Test plan
- [ ] Run an iperf UDP benchmark and verify the server starts with `--udp` flag
- [ ] Verify error detection works when server fails to start

🤖 Generated with [Claude Code](https://claude.com/claude-code)